### PR TITLE
Add a define on POSIX system for lua to silence a warning about tmpname vs mkstmp

### DIFF
--- a/thirdparty/build/lua.lua
+++ b/thirdparty/build/lua.lua
@@ -8,3 +8,11 @@ LIBRARY.Files = {
 	"../thirdparty/src/Lua/*.h",
 	"../thirdparty/src/Lua/*.cpp"
 }
+
+LIBRARY.OsDefines.Windows = {
+	"LUA_USE_WINDOWS"
+}
+
+LIBRARY.OsDefines.Posix = {
+	"LUA_USE_LINUX"
+}


### PR DESCRIPTION
Since the define LUA_USE_MACOSX and LUA_USE_LINUX seems to lead to the same subdefine it will do the job