### PR TITLE
Build Nazara on macos (everything compile except NazaraVulkan/OpenGLRenderer)

### DIFF
--- a/build/scripts/common.lua
+++ b/build/scripts/common.lua
@@ -158,6 +158,15 @@ function NazaraBuild:Execute()
 				"../src/",
 				"../thirdparty/include"
 			})
+			
+			if (os.ishost("macosx")) then
+				includedirs({
+					"../include",
+					"../src/",
+					"../thirdparty/include",
+					"/usr/local/include/" --brew
+				})
+			end
 
 			files(moduleTable.Files)
 			excludes(moduleTable.FilesExcluded)
@@ -171,6 +180,14 @@ function NazaraBuild:Execute()
 				"../thirdparty/lib/common",
 				"../lib"
 			})
+			
+			if (os.ishost("macosx")) then
+				libdirs({
+					"../thirdparty/lib/common",
+					"../lib",
+					"/usr/local/lib" --brew
+				})
+			end
 
 			-- Output to lib/conf/arch
 			self:FilterLibDirectory("../lib/", targetdir)
@@ -928,7 +945,10 @@ end
 
 function NazaraBuild:PostconfigGenericProject()
 	-- Add options required for C++17 thread and filesystem (have to be linked last)
-	filter("action:gmake*")
+	filter({"action:gmake*", "system:macosx"})
+		links("pthread")
+		
+	filter({"action:gmake*", "system:not macosx"})
 		links("stdc++fs")
 		links("pthread")
 

--- a/build/scripts/modules/physics3d.lua
+++ b/build/scripts/modules/physics3d.lua
@@ -21,4 +21,10 @@ MODULE.Custom = function()
 
 	filter({"architecture:x86", "system:linux"})
 		defines("_POSIX_VER")
+	
+	filter({"architecture:x86_64", "system:macosx"})
+		defines("_POSIX_VER_64")
+
+	filter({"architecture:x86", "system:macosx"})
+		defines("_POSIX_VER")
 end

--- a/build/scripts/modules/platform.lua
+++ b/build/scripts/modules/platform.lua
@@ -21,11 +21,15 @@ MODULE.OsDefines.Windows = {
 	"SDL_VIDEO_DRIVER_WINDOWS=1"
 }
 
-MODULE.OsDefines.Posix = {
-	"SDL_VIDEO_DRIVER_X11=1",
-	"SDL_VIDEO_DRIVER_WAYLAND=1",
-}
-
 MODULE.DynLib = {
 	"SDL2"
 }
+
+MODULE.Custom = function()
+	filter("system:linux")
+		defines("SDL_VIDEO_DRIVER_X11=1")
+		defines("SDL_VIDEO_DRIVER_WAYLAND=1")
+
+	filter("system:macosx")
+		defines("SDL_VIDEO_DRIVER_COCOA=1")
+end

--- a/include/Nazara/Math/Angle.inl
+++ b/include/Nazara/Math/Angle.inl
@@ -97,7 +97,7 @@ namespace Nz
 			}
 		};
 
-#ifdef NAZARA_PLATFORM_POSIX
+#ifdef NAZARA_PLATFORM_LINUX
 		template<typename T>
 		void SinCos(std::enable_if_t<!std::is_same<T, float>::value && !std::is_same<T, long double>::value, double> x, T* sin, T* cos)
 		{

--- a/include/Nazara/Prerequisites.hpp
+++ b/include/Nazara/Prerequisites.hpp
@@ -121,9 +121,12 @@
 
 	#define NAZARA_EXPORT __attribute__((visibility ("default")))
 	#define NAZARA_IMPORT __attribute__((visibility ("default")))
-/*#elif defined(__APPLE__) && defined(__MACH__)
- #define NAZARA_PLATFORM_MACOSX
- #define NAZARA_PLATFORM_POSIX*/
+#elif defined(__APPLE__) && defined(__MACH__)
+    #define NAZARA_PLATFORM_MACOSX
+    #define NAZARA_PLATFORM_POSIX
+	
+	#define NAZARA_EXPORT __attribute__((visibility ("default")))
+	#define NAZARA_IMPORT __attribute__((visibility ("default")))
 #else
 	#error This operating system is not fully supported by the Nazara Engine
 

--- a/include/Nazara/Shader/ShaderAstSerializer.hpp
+++ b/include/Nazara/Shader/ShaderAstSerializer.hpp
@@ -68,7 +68,6 @@ namespace Nz
 			virtual void Value(UInt16& val) = 0;
 			virtual void Value(UInt32& val) = 0;
 			virtual void Value(UInt64& val) = 0;
-			virtual void Value(std::size_t& val) = 0;
 			inline void SizeT(std::size_t& val);
 
 			virtual void Variable(ShaderNodes::VariablePtr& var) = 0;
@@ -102,7 +101,6 @@ namespace Nz
 			void Value(UInt16& val) override;
 			void Value(UInt32& val) override;
 			void Value(UInt64& val) override;
-			void Value(std::size_t& val) override;
 			void Variable(ShaderNodes::VariablePtr& var) override;
 
 			ByteStream& m_stream;
@@ -134,7 +132,6 @@ namespace Nz
 			void Value(UInt16& val) override;
 			void Value(UInt32& val) override;
 			void Value(UInt64& val) override;
-			void Value(std::size_t& val) override;
 			void Variable(ShaderNodes::VariablePtr& var) override;
 
 			ByteStream& m_stream;

--- a/include/Nazara/Shader/ShaderAstSerializer.hpp
+++ b/include/Nazara/Shader/ShaderAstSerializer.hpp
@@ -68,6 +68,7 @@ namespace Nz
 			virtual void Value(UInt16& val) = 0;
 			virtual void Value(UInt32& val) = 0;
 			virtual void Value(UInt64& val) = 0;
+			virtual void Value(std::size_t& val) = 0;
 			inline void SizeT(std::size_t& val);
 
 			virtual void Variable(ShaderNodes::VariablePtr& var) = 0;
@@ -101,6 +102,7 @@ namespace Nz
 			void Value(UInt16& val) override;
 			void Value(UInt32& val) override;
 			void Value(UInt64& val) override;
+			void Value(std::size_t& val) override;
 			void Variable(ShaderNodes::VariablePtr& var) override;
 
 			ByteStream& m_stream;
@@ -132,6 +134,7 @@ namespace Nz
 			void Value(UInt16& val) override;
 			void Value(UInt32& val) override;
 			void Value(UInt64& val) override;
+			void Value(std::size_t& val) override;
 			void Variable(ShaderNodes::VariablePtr& var) override;
 
 			ByteStream& m_stream;

--- a/src/Nazara/Audio/OpenAL.cpp
+++ b/src/Nazara/Audio/OpenAL.cpp
@@ -132,7 +132,11 @@ namespace Nz
 			"libopenal.so.0",
 			"libopenal.so"
 		};
-		//#elif defined(NAZARA_PLATFORM_MACOSX)
+		#elif defined(NAZARA_PLATFORM_MACOSX)
+		const char* libs[] = {
+			"libopenal.dylib",
+			"libopenal.1.dylib",
+		};
 		#else
 		NazaraError("Unknown OS");
 		return false;

--- a/src/Nazara/Core/Posix/FileImpl.cpp
+++ b/src/Nazara/Core/Posix/FileImpl.cpp
@@ -31,8 +31,8 @@ namespace Nz
 	{
 		if (!m_endOfFileUpdated)
 		{
-			struct stat64 fileSize;
-			if (fstat64(m_fileDescriptor, &fileSize) == -1)
+			struct Stat fileSize;
+			if (Fstat(m_fileDescriptor, &fileSize) == -1)
 				fileSize.st_size = 0;
 
 			m_endOfFile = (GetCursorPos() >= static_cast<UInt64>(fileSize.st_size));
@@ -50,7 +50,7 @@ namespace Nz
 
 	UInt64 FileImpl::GetCursorPos() const
 	{
-		off64_t position = lseek64(m_fileDescriptor, 0, SEEK_CUR);
+		Off_t position = Lseek(m_fileDescriptor, 0, SEEK_CUR);
 		return static_cast<UInt64>(position);
 	}
 
@@ -77,7 +77,7 @@ namespace Nz
 		if (mode & OpenMode_Truncate)
 			flags |= O_TRUNC;
 
-		int fileDescriptor = open64(filePath.generic_u8string().data(), flags, permissions);
+		int fileDescriptor = Open_def(filePath.generic_u8string().data(), flags, permissions);
 		if (fileDescriptor == -1)
 		{
 			NazaraError("Failed to open \"" + filePath.generic_u8string() + "\" : " + Error::GetLastSystemError());
@@ -166,12 +166,12 @@ namespace Nz
 
 		m_endOfFileUpdated = false;
 
-		return lseek64(m_fileDescriptor, offset, moveMethod) != -1;
+		return Lseek(m_fileDescriptor, offset, moveMethod) != -1;
 	}
 
 	bool FileImpl::SetSize(UInt64 size)
 	{
-		return ftruncate64(m_fileDescriptor, size) != 0;
+		return Ftruncate(m_fileDescriptor, size) != 0;
 	}
 
 	std::size_t FileImpl::Write(const void* buffer, std::size_t size)

--- a/src/Nazara/Core/Posix/FileImpl.hpp
+++ b/src/Nazara/Core/Posix/FileImpl.hpp
@@ -16,6 +16,24 @@
 #include <ctime>
 #include <filesystem>
 
+#if defined(NAZARA_PLATFORM_MACOSX)
+	#define Stat stat
+	#define Fstat fstat
+	#define Off_t off_t
+	#define Lseek lseek
+	#define Open_def open
+	#define Ftruncate ftruncate
+#elif defined(NAZARA_PLATFORM_LINUX)
+	#define Stat stat64
+	#define Fstat fstat64
+	#define Off_t off64_t
+	#define Lseek lseek64
+	#define Open_def open64
+	#define Ftruncate ftruncate64
+#else
+    #error This operating system is not fully supported by the Nazara Engine
+#endif
+
 namespace Nz
 {
 	class File;

--- a/src/Nazara/Core/Posix/TaskSchedulerImpl.cpp
+++ b/src/Nazara/Core/Posix/TaskSchedulerImpl.cpp
@@ -6,6 +6,10 @@
 #include <Nazara/Core/Functor.hpp>
 #include <Nazara/Core/Debug.hpp>
 
+#if defined(NAZARA_PLATFORM_MACOSX)
+	#include <errno.h>
+#endif
+
 namespace Nz
 {
 	bool TaskSchedulerImpl::Initialize(unsigned int workerCount)
@@ -191,4 +195,55 @@ namespace Nz
 	pthread_cond_t TaskSchedulerImpl::s_cvEmpty;
 	pthread_cond_t TaskSchedulerImpl::s_cvNotEmpty;
 	pthread_barrier_t TaskSchedulerImpl::s_barrier;
+	
+#if defined(NAZARA_PLATFORM_MACOSX)
+    //Code from https://blog.albertarmea.com/post/47089939939/using-pthreadbarrier-on-mac-os-x
+	int TaskSchedulerImpl::pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count)
+	{
+		if(count == 0)
+		{
+			errno = EINVAL;
+			return -1;
+		}
+		if(pthread_mutex_init(&barrier->mutex, 0) < 0)
+		{
+			return -1;
+		}
+		if(pthread_cond_init(&barrier->cond, 0) < 0)
+		{
+			pthread_mutex_destroy(&barrier->mutex);
+			return -1;
+		}
+		barrier->tripCount = count;
+		barrier->count = 0;
+
+		return 0;
+	}
+
+	int TaskSchedulerImpl::pthread_barrier_destroy(pthread_barrier_t *barrier)
+	{
+		pthread_cond_destroy(&barrier->cond);
+		pthread_mutex_destroy(&barrier->mutex);
+		return 0;
+	}
+
+	int TaskSchedulerImpl::pthread_barrier_wait(pthread_barrier_t *barrier)
+	{
+		pthread_mutex_lock(&barrier->mutex);
+		++(barrier->count);
+		if(barrier->count >= barrier->tripCount)
+		{
+			barrier->count = 0;
+			pthread_cond_broadcast(&barrier->cond);
+			pthread_mutex_unlock(&barrier->mutex);
+			return 1;
+		}
+		else
+		{
+			pthread_cond_wait(&barrier->cond, &(barrier->mutex));
+			pthread_mutex_unlock(&barrier->mutex);
+			return 0;
+		}
+	}
+#endif
 }

--- a/src/Nazara/Core/Posix/TaskSchedulerImpl.hpp
+++ b/src/Nazara/Core/Posix/TaskSchedulerImpl.hpp
@@ -13,6 +13,17 @@
 #include <pthread.h>
 #include <queue>
 
+#if defined(NAZARA_PLATFORM_MACOSX)
+	typedef int pthread_barrierattr_t;
+	typedef struct
+	{
+		pthread_mutex_t mutex;
+		pthread_cond_t cond;
+		int count;
+		int tripCount;
+	} pthread_barrier_t;
+#endif
+
 namespace Nz
 {
 	struct Functor;
@@ -45,6 +56,12 @@ namespace Nz
 			static pthread_cond_t s_cvEmpty;
 			static pthread_cond_t s_cvNotEmpty;
 			static pthread_barrier_t s_barrier;
+
+#if defined(NAZARA_PLATFORM_MACOSX)
+			static int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count);
+			static int pthread_barrier_destroy(pthread_barrier_t *barrier);
+			static int pthread_barrier_wait(pthread_barrier_t *barrier);
+#endif
 	};
 }
 

--- a/src/Nazara/Core/Stream.cpp
+++ b/src/Nazara/Core/Stream.cpp
@@ -157,7 +157,7 @@ namespace Nz
 #elif defined(NAZARA_PLATFORM_LINUX)
 			std::string_view temp(string);
 			// Nothing to do
-#elif defined(NAZARA_PLATFORM_MACOS)
+#elif defined(NAZARA_PLATFORM_MACOSX)
 			std::string temp(string);
 			ReplaceStr(temp, "\n", "\r");
 #endif

--- a/src/Nazara/Network/Posix/SocketImpl.cpp
+++ b/src/Nazara/Network/Posix/SocketImpl.cpp
@@ -19,7 +19,7 @@
 
 #if !defined(TCP_KEEPIDLE) && defined(TCP_KEEPALIVE)
 #define TCP_KEEPIDLE TCP_KEEPALIVE // see -> https://gitlab.freedesktop.org/spice/usbredir/-/issues/9
-#endi
+#endif
 
 namespace Nz
 {
@@ -601,7 +601,7 @@ namespace Nz
 		}
 
 		IpAddress senderIp;
-#if not defined(MSG_NOSIGNAL)
+#if defined(MSG_NOSIGNAL)
 		int byteRead = recvmsg(handle, &msgHdr, MSG_NOSIGNAL);
 #else
 		int byteRead = recvmsg(handle, &msgHdr, 0);
@@ -721,7 +721,7 @@ namespace Nz
 		msgHdr.msg_iov = sysBuffers.data();
 		msgHdr.msg_iovlen = static_cast<int>(bufferCount);
 
-#if not defined(MSG_NOSIGNAL)
+#if defined(MSG_NOSIGNAL)
 		int byteSent = sendmsg(handle, &msgHdr, MSG_NOSIGNAL);
 #else
 		int byteSent = sendmsg(handle, &msgHdr, 0);

--- a/src/Nazara/Network/Posix/SocketImpl.cpp
+++ b/src/Nazara/Network/Posix/SocketImpl.cpp
@@ -273,6 +273,9 @@ namespace Nz
 		unsigned int code;
 		socklen_t codeLength = sizeof(code);
 
+#if defined(NAZARA_PLATFORM_MACOSX)
+		return 0; //No IP_MTU on macosx
+#else
 		if (getsockopt(handle, IPPROTO_IP, IP_MTU, &code, &codeLength) == SOCKET_ERROR)
 		{
 			if (error)
@@ -280,6 +283,7 @@ namespace Nz
 
 			return 0;
 		}
+#endif
 
 		if (error)
 			*error = SocketError_NoError;

--- a/src/Nazara/Shader/ShaderAstSerializer.cpp
+++ b/src/Nazara/Shader/ShaderAstSerializer.cpp
@@ -258,7 +258,7 @@ namespace Nz
 
 	void ShaderAstSerializerBase::Serialize(ShaderNodes::SwizzleOp& node)
 	{
-		Value(node.componentCount);
+		SizeT(node.componentCount);
 		Node(node.expression);
 
 		for (std::size_t i = 0; i < node.componentCount; ++i)
@@ -462,11 +462,6 @@ namespace Nz
 	}
 
 	void ShaderAstSerializer::Value(UInt64& val)
-	{
-		m_stream << val;
-	}
-	
-	void ShaderAstSerializer::Value(std::size_t& val)
 	{
 		m_stream << val;
 	}
@@ -737,11 +732,6 @@ namespace Nz
 		m_stream >> val;
 	}
 	
-	void ShaderAstUnserializer::Value(std::size_t& val)
-	{
-		m_stream >> val;
-	}
-
 	void ShaderAstUnserializer::Variable(ShaderNodes::VariablePtr& var)
 	{
 		Int32 nodeTypeInt;

--- a/src/Nazara/Shader/ShaderAstSerializer.cpp
+++ b/src/Nazara/Shader/ShaderAstSerializer.cpp
@@ -465,6 +465,11 @@ namespace Nz
 	{
 		m_stream << val;
 	}
+	
+	void ShaderAstSerializer::Value(std::size_t& val)
+	{
+		m_stream << val;
+	}
 
 	void ShaderAstSerializer::Variable(ShaderNodes::VariablePtr& var)
 	{
@@ -728,6 +733,11 @@ namespace Nz
 	}
 
 	void ShaderAstUnserializer::Value(UInt64& val)
+	{
+		m_stream >> val;
+	}
+	
+	void ShaderAstUnserializer::Value(std::size_t& val)
 	{
 		m_stream >> val;
 	}

--- a/src/ShaderNode/DataModels/BufferField.cpp
+++ b/src/ShaderNode/DataModels/BufferField.cpp
@@ -332,7 +332,7 @@ void BufferField::PopulateFieldList(std::size_t structIndex, const std::string& 
 			else if constexpr (std::is_same_v<T, std::size_t>)
 				PopulateFieldList(arg, prefix + member.name + ".");
 			else
-				static_assert(AlwaysFalse<T>::value, "non-exhaustive visitor");
+				static_assert(Nz::AlwaysFalse<T>::value, "non-exhaustive visitor");
 		},
 		member.type);
 	}

--- a/src/ShaderNode/DataModels/Cast.inl
+++ b/src/ShaderNode/DataModels/Cast.inl
@@ -2,6 +2,7 @@
 #include <Nazara/Shader/ShaderBuilder.hpp>
 #include <QtWidgets/QDoubleSpinBox>
 #include <QtWidgets/QFormLayout>
+#include <QtCore/QJsonArray>
 #include <stdexcept>
 
 template<std::size_t ToComponentCount>

--- a/src/ShaderNode/DataTypes/VecData.hpp
+++ b/src/ShaderNode/DataTypes/VecData.hpp
@@ -48,7 +48,7 @@ struct VecExpressionTypeHelper<4>
 	static constexpr Nz::ShaderNodes::BasicType ExpressionType = Nz::ShaderNodes::BasicType::Float4;
 };
 
-template<std::size_t N> constexpr Nz::ShaderNodes::BasicType VecExpressionType = VecExpressionTypeHelper<N>::template ExpressionType;
+template<std::size_t N> constexpr Nz::ShaderNodes::BasicType VecExpressionType = VecExpressionTypeHelper<N>::ExpressionType;
 
 
 struct VecTypeDummy {};
@@ -86,7 +86,7 @@ struct VecTypeHelper<4>
 	using Type = Nz::Vector4f;
 };
 
-template<std::size_t N> using VecType = typename VecTypeHelper<N>::template Type;
+template<std::size_t N> using VecType = typename VecTypeHelper<N>::Type;
 
 constexpr std::array<char, 4> s_vectorComponents = { 'X', 'Y', 'Z', 'W' };
 

--- a/src/ShaderNode/ShaderGraph.cpp
+++ b/src/ShaderNode/ShaderGraph.cpp
@@ -64,7 +64,7 @@ m_type(ShaderType::NotSet)
 			{ "position", PrimitiveType::Float3 },
 			{ "normal", PrimitiveType::Float3 },
 			{ "uv", PrimitiveType::Float2 },
-			{ "inner", 2 }
+			{ "inner", 2u }
 		}
 	});
 	AddStruct("InnerStruct", {
@@ -74,7 +74,7 @@ m_type(ShaderType::NotSet)
 	});
 	AddStruct("OuterStruct", {
 		{
-			{ "a", 1 },
+			{ "a", 1u },
 			{ "b", PrimitiveType::Float1 }
 		}
 	});
@@ -266,7 +266,7 @@ void ShaderGraph::Load(const QJsonObject& data)
 			if (typeDocRef.isString())
 				memberInfo.type = DecodeEnum<PrimitiveType>(typeDocRef.toString().toStdString()).value();
 			else
-				memberInfo.type = typeDocRef.toInt();
+				memberInfo.type = static_cast<std::size_t>(typeDocRef.toInt());
 		}
 	}
 
@@ -363,7 +363,7 @@ QJsonObject ShaderGraph::Save()
 					else if constexpr (std::is_same_v<T, std::size_t>)
 						memberDoc["type"] = int(arg);
 					else
-						static_assert(AlwaysFalse<T>::value, "non-exhaustive visitor");
+						static_assert(Nz::AlwaysFalse<T>::value, "non-exhaustive visitor");
 				}, member.type);
 
 				memberArray.append(std::move(memberDoc));
@@ -535,7 +535,7 @@ Nz::ShaderExpressionType ShaderGraph::ToShaderExpressionType(const std::variant<
 			return s.name;
 		}
 		else
-			static_assert(AlwaysFalse<T>::value, "non-exhaustive visitor");
+			static_assert(Nz::AlwaysFalse<T>::value, "non-exhaustive visitor");
 	}, type);
 };
 

--- a/src/ShaderNode/Widgets/MainWindow.cpp
+++ b/src/ShaderNode/Widgets/MainWindow.cpp
@@ -269,7 +269,7 @@ Nz::ShaderAst MainWindow::ToShader()
 				else if constexpr (std::is_same_v<T, std::size_t>)
 					member.type = m_shaderGraph.GetStruct(arg).name;
 				else
-					static_assert(AlwaysFalse<T>::value, "non-exhaustive visitor");
+					static_assert(Nz::AlwaysFalse<T>::value, "non-exhaustive visitor");
 			}, sMember.type);
 		}
 

--- a/src/ShaderNode/Widgets/StructEditDialog.cpp
+++ b/src/ShaderNode/Widgets/StructEditDialog.cpp
@@ -97,7 +97,7 @@ QString StructEditDialog::GetMemberName(const StructInfo::Member& member)
 		else if constexpr (std::is_same_v<T, std::size_t>)
 			name += QString::fromStdString(m_shaderGraph.GetStruct(arg).name);
 		else
-			static_assert(AlwaysFalse<T>::value, "non-exhaustive visitor");
+			static_assert(Nz::AlwaysFalse<T>::value, "non-exhaustive visitor");
 	},
 	member.type);
 

--- a/src/ShaderNode/Widgets/StructMemberEditDialog.cpp
+++ b/src/ShaderNode/Widgets/StructMemberEditDialog.cpp
@@ -50,7 +50,7 @@ StructMemberEditDialog(shaderGraph, parent)
 		else if constexpr (std::is_same_v<T, std::size_t>)
 			m_typeList->setCurrentIndex(static_cast<int>(PrimitiveTypeCount + arg));
 		else
-			static_assert(AlwaysFalse<T>::value, "non-exhaustive visitor");
+			static_assert(Nz::AlwaysFalse<T>::value, "non-exhaustive visitor");
 	},
 	member.type);
 }

--- a/thirdparty/build/newton.lua
+++ b/thirdparty/build/newton.lua
@@ -36,4 +36,10 @@ LIBRARY.Custom = function()
 
 	filter({"architecture:x86", "system:linux"})
 		defines("_POSIX_VER")
+		
+	filter({"architecture:x86_64", "system:macosx"})
+		defines("_POSIX_VER_64")
+
+	filter({"architecture:x86", "system:macosx"})
+		defines("_POSIX_VER")
 end

--- a/thirdparty/build/newton.lua
+++ b/thirdparty/build/newton.lua
@@ -38,8 +38,5 @@ LIBRARY.Custom = function()
 		defines("_POSIX_VER")
 		
 	filter({"architecture:x86_64", "system:macosx"})
-		defines("_POSIX_VER_64")
-
-	filter({"architecture:x86", "system:macosx"})
-		defines("_POSIX_VER")
+		defines("_MACOSX_VER")
 end


### PR DESCRIPTION
What this PR does:
- Change some functions name in NazaraCore (remove 64 suffix not present in macos)
- add the proper defines for Newton and Physics3D
- add functions for pthread_barrier (taken from https://blog.albertarmea.com/post/47089939939/using-pthreadbarrier-on-mac-os-x)
- allow brew files to be used
- set cocoa video driver for macos with sdl
- add openal libs name on macos
- use std::sin and std::cos for macos (no sincos)
- Fix a call to Value(std::size_t&) which should be SizeT(std::size_t&)
- Fix TCP_KEEPIDLE, MSG_NOSIGNAL and IP_MTU not being present on macos
- Fix ShaderNodes compilation on macos