### PR TITLE
SocketPoller: correctly initialize to NoError

### DIFF
--- a/src/Nazara/Network/Posix/SocketImpl.cpp
+++ b/src/Nazara/Network/Posix/SocketImpl.cpp
@@ -395,6 +395,9 @@ namespace Nz
 			return 0;
 		}
 
+		if (error)
+			*error = SocketError::NoError;
+
 		return static_cast<unsigned int>(result);
 	}
 


### PR DESCRIPTION
Initialize the error accumulator to SockerError::NoError. Otherwise, the
error wasn't initialized in the non-error path, and the poller was
reaching an unknown error because of that.

Fix SocketPollerTest on MacOS.