### PR TITLE
WIP: Add MoltenVK for MacOS

### DIFF
--- a/src/Nazara/VulkanRenderer/Wrapper/Loader.cpp
+++ b/src/Nazara/VulkanRenderer/Wrapper/Loader.cpp
@@ -68,6 +68,8 @@ namespace Nz
 			s_vulkanLib.Load("vulkan-1.dll");
 			#elif defined(NAZARA_PLATFORM_LINUX)
 			s_vulkanLib.Load("libvulkan.so");
+			#elif defined(NAZARA_PLATFORM_MACOS)
+			s_vulkanLib.Load("libMoltenVK.dylib");
 			#else
 			#error Unhandled platform
 			#endif

--- a/xmake.lua
+++ b/xmake.lua
@@ -103,7 +103,6 @@ local modules = {
 				add_defines("VK_USE_PLATFORM_WAYLAND_KHR")
 			elseif is_plat("macosx") then
 				add_defines("VK_USE_PLATFORM_METAL_EXT")
-				add_packages("moltenvk")
 			end
 		end
 	},
@@ -139,7 +138,7 @@ add_requires("openal-soft", { configs = { shared = true }})
 add_requires("newtondynamics", { debug = is_plat("windows") and is_mode("debug") }) -- Newton doesn't like compiling in Debug on Linux
 
 if is_plat("macosx") then
-	add_requires("libx11", "moltenvk")
+	add_requires("libx11")
 end
 
 add_rules("mode.asan", "mode.coverage", "mode.debug", "mode.releasedbg")

--- a/xmake.lua
+++ b/xmake.lua
@@ -85,6 +85,9 @@ local modules = {
 		Custom = function()
 			-- Set precise floating-points models to ensure shader optimization leads to correct results
 			set_fpmodels("precise")
+			if is_plat("macosx") then
+				add_packages("molten-vk")
+			end
 		end
 	},
 	Utility = {
@@ -103,12 +106,19 @@ local modules = {
 				add_defines("VK_USE_PLATFORM_WAYLAND_KHR")
 			elseif is_plat("macosx") then
 				add_defines("VK_USE_PLATFORM_METAL_EXT")
+				add_packages("molten-vk")
 			end
 		end
 	},
 	Widgets = {
 		Deps = {"NazaraGraphics"},
-		Packages = {"entt", "kiwisolver"}
+		Packages = {"entt", "kiwisolver"},
+		Custom = function()
+			if is_plat("macosx") then
+				add_packages("molten-vk")
+			end
+		end
+
 	}
 }
 
@@ -139,6 +149,7 @@ add_requires("newtondynamics", { debug = is_plat("windows") and is_mode("debug")
 
 if is_plat("macosx") then
 	add_requires("libx11")
+	add_requires("molten-vk")
 end
 
 add_rules("mode.asan", "mode.coverage", "mode.debug", "mode.releasedbg")

--- a/xmake.lua
+++ b/xmake.lua
@@ -85,9 +85,6 @@ local modules = {
 		Custom = function()
 			-- Set precise floating-points models to ensure shader optimization leads to correct results
 			set_fpmodels("precise")
-			if is_plat("macosx") then
-				add_packages("molten-vk")
-			end
 		end
 	},
 	Utility = {
@@ -106,17 +103,13 @@ local modules = {
 				add_defines("VK_USE_PLATFORM_WAYLAND_KHR")
 			elseif is_plat("macosx") then
 				add_defines("VK_USE_PLATFORM_METAL_EXT")
-				add_packages("molten-vk")
+				add_packages("moltenvk")
 			end
 		end
 	},
 	Widgets = {
 		Deps = {"NazaraGraphics"},
-		Packages = {"entt", "kiwisolver"},
-		Custom = function()
-			if is_plat("macosx") then
-				add_packages("molten-vk")
-			end
+		Packages = {"entt", "kiwisolver"}
 		end
 
 	}
@@ -148,8 +141,7 @@ add_requires("openal-soft", { configs = { shared = true }})
 add_requires("newtondynamics", { debug = is_plat("windows") and is_mode("debug") }) -- Newton doesn't like compiling in Debug on Linux
 
 if is_plat("macosx") then
-	add_requires("libx11")
-	add_requires("molten-vk")
+	add_requires("libx11", "moltenvk")
 end
 
 add_rules("mode.asan", "mode.coverage", "mode.debug", "mode.releasedbg")

--- a/xmake.lua
+++ b/xmake.lua
@@ -110,8 +110,6 @@ local modules = {
 	Widgets = {
 		Deps = {"NazaraGraphics"},
 		Packages = {"entt", "kiwisolver"}
-		end
-
 	}
 }
 


### PR DESCRIPTION
Pending work to support Vulkan renderer on MacOS.

Currently stuck at:

```
 Error: Failed to get vkCmdBeginDebugUtilsLabelEXT address (include/Nazara/VulkanRenderer/Wrapper/Instance.inl:56: PFN_vkVoidFunction Nz::Vk::Instance::GetDeviceProcAddr(VkDevice, const char *) const)
Error: Failed to query device function: Failed to get vkCmdBeginDebugUtilsLabelEXT address (src/Nazara/VulkanRenderer/Wrapper/Device.cpp:107: bool Nz::Vk::Device::Create(const Vk::PhysicalDevice &, const VkDeviceCreateInfo &, const VkAllocationCallbacks *))
libc++abi: terminating with uncaught exception of type std::runtime_error: Failed to query device function: Failed to get vkCmdBeginDebugUtilsLabelEXT address
error: execv(/Users/unidan/Workspace/NazaraEngine/bin/macosx_x86_64_debug/WidgetDemo) failed(-1)
```

See https://github.com/KhronosGroup/MoltenVK/issues/1511