### PR TITLE
Update xmake.lua in order to compile on my Ubuntu machine

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -28,6 +28,7 @@ local rendererBackends = {
 				add_defines("VK_USE_PLATFORM_XLIB_KHR")
 				add_defines("VK_USE_PLATFORM_WAYLAND_KHR")
 				add_packages("wayland", { links = {} }) -- we only need wayland headers
+				add_packages("libx11", { links = {} }) -- we only need X11 headers
 			elseif is_plat("macosx") then
 				add_defines("VK_USE_PLATFORM_METAL_EXT")
 				add_files("src/Nazara/VulkanRenderer/**.mm")
@@ -96,6 +97,7 @@ local modules = {
 			elseif is_plat("linux") then
 				add_defines("SDL_VIDEO_DRIVER_X11=1")
 				add_defines("SDL_VIDEO_DRIVER_WAYLAND=1")
+				add_packages("libx11", { links = {} }) -- we only need X11 headers
 			elseif is_plat("macosx") then
 				add_defines("SDL_VIDEO_DRIVER_COCOA=1")
 				add_packages("libx11", { links = {} }) -- we only need X11 headers
@@ -162,7 +164,7 @@ add_requires("nazarautils")
 add_requires("nzsl", { debug = is_mode("debug"), configs = { with_symbols = not is_mode("release"), shared = true } })
 
 if is_plat("linux") then
-	add_requires("libuuid", "wayland")
+	add_requires("libuuid", "wayland", "libx11")
 elseif is_plat("macosx") then
 	add_requires("libx11")
 end


### PR DESCRIPTION
On my Ubuntu machine
```bash
ciotatsoft@ciotatsoft:~/dev/nazara_ciotatsoft/NazaraEngine$ uname -a
Linux ciotatsoft 5.15.0-52-generic #58-Ubuntu SMP Thu Oct 13 08:03:55 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```

a simple checkout of NazaraEngine followed by:
```bash
xmake config -v
xmake -v
```
leads to the the following errors:
```bash
[ 31%]: cache compiling.debug src/Nazara/VulkanRenderer/VulkanRenderPass.cpp
/usr/bin/gcc -c -m64 -fPIC -g -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -O0 -std=c++17 -Iinclude -Isrc -DNAZARA_DEBUG -DNAZARA_BUILD -DNAZARA_UTILS_WINDOWS_NT6=1 -DNAZARA_VULKANRENDERER_BUILD -DNAZARA_VULKANRENDERER_DEBUG -DVK_NO_PROTOTYPES -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_WAYLAND_KHR -isystem thirdparty/include -isystem /home/ciotatsoft/.xmake/packages/w/wayland/1.19.0/d4813a414d234036bb8606e1e07c959d/include -isystem /usr/include/libxml2 -isystem /home/ciotatsoft/.xmake/packages/n/nzsl/2022.11.05/7eba85378273494b9e3be7014587001c/include -isystem /home/ciotatsoft/.xmake/packages/f/fmt/9.1.0/d363b063d73b40728217e45838c2553c/include -isystem /home/ciotatsoft/.xmake/packages/f/frozen/1.1.1/d615117ff2e045069cd8c372d0615141/include -isystem /home/ciotatsoft/.xmake/packages/o/ordered_map/v1.0.0/93b4db00d0714ef699b7f3e84f3868f6/include -isystem /home/ciotatsoft/.xmake/packages/e/efsw/1.1.0/66604350ac58480999044952b103396c/include -isystem /home/ciotatsoft/.xmake/packages/n/nazarautils/2022.11.15/89909ada99b54eba83c36de5bb951f1a/include -o build/.objs/NazaraVulkanRenderer/linux/x86_64/debug/src/Nazara/VulkanRenderer/VulkanRenderPass.cpp.o src/Nazara/VulkanRenderer/VulkanRenderPass.cpp
error: In file included from thirdparty/include/vma/vk_mem_alloc.h:130,
                 from src/Nazara/VulkanRenderer/VulkanTexture.cpp:10:
thirdparty/include/vulkan/vulkan.h:59:10: fatal error: X11/Xlib.h: No such file or directory
   59 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.
ciotatsoft@ciotatsoft:~/dev/nazara_ciotatsoft/NazaraEngine$ 
```

and 

```bash
[ 34%]: cache compiling.debug src/Nazara/VulkanRenderer/VulkanTexture.cpp
/usr/bin/gcc -c -m64 -fPIC -g -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -O0 -std=c++17 -Iinclude -Isrc -DNAZARA_DEBUG -DNAZARA_BUILD -DNAZARA_UTILS_WINDOWS_NT6=1 -DNAZARA_VULKANRENDERER_BUILD -DNAZARA_VULKANRENDERER_DEBUG -DVK_NO_PROTOTYPES -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_WAYLAND_KHR -isystem thirdparty/include -isystem /home/ciotatsoft/.xmake/packages/w/wayland/1.19.0/d4813a414d234036bb8606e1e07c959d/include -isystem /usr/include/libxml2 -isystem /home/ciotatsoft/.xmake/packages/n/nzsl/2022.11.05/7eba85378273494b9e3be7014587001c/include -isystem /home/ciotatsoft/.xmake/packages/f/fmt/9.1.0/d363b063d73b40728217e45838c2553c/include -isystem /home/ciotatsoft/.xmake/packages/f/frozen/1.1.1/d615117ff2e045069cd8c372d0615141/include -isystem /home/ciotatsoft/.xmake/packages/o/ordered_map/v1.0.0/93b4db00d0714ef699b7f3e84f3868f6/include -isystem /home/ciotatsoft/.xmake/packages/e/efsw/1.1.0/66604350ac58480999044952b103396c/include -isystem /home/ciotatsoft/.xmake/packages/n/nazarautils/2022.11.15/89909ada99b54eba83c36de5bb951f1a/include -o build/.objs/NazaraVulkanRenderer/linux/x86_64/debug/src/Nazara/VulkanRenderer/VulkanTexture.cpp.o src/Nazara/VulkanRenderer/VulkanTexture.cpp
error: In file included from src/Nazara/Platform/SDL2/WindowImpl.cpp:16:
/home/ciotatsoft/.xmake/packages/l/libsdl/2.24.0/881313b101a44f42b21475bb8d394740/include/SDL2/SDL_syswm.h:69:10: fatal error: X11/Xlib.h: No such file or directory
   69 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.
ciotatsoft@ciotatsoft:~/dev/nazara_ciotatsoft/NazaraEngine$ 
```

where we see that the include directory of `X11` headers is missing for the compilation of `SDL` and `Vulkan`.

-----

This ticket fixes the compilation on my machine