### PR TITLE
Utility : Fixed STBSaver supported file extensions

### DIFF
--- a/src/Nazara/Utility/Formats/STBSaver.cpp
+++ b/src/Nazara/Utility/Formats/STBSaver.cpp
@@ -262,12 +262,12 @@ namespace Nz
 	{
 		ImageSaver::Entry GetImageSaver_STB()
 		{
-			s_formatHandlers["bmp"] = &SaveBMP;
-			s_formatHandlers["hdr"] = &SaveHDR;
-			s_formatHandlers["jpg"] = &SaveJPEG;
-			s_formatHandlers["jpeg"] = &SaveJPEG;
-			s_formatHandlers["png"] = &SavePNG;
-			s_formatHandlers["tga"] = &SaveTGA;
+			s_formatHandlers[".bmp"] = &SaveBMP;
+			s_formatHandlers[".hdr"] = &SaveHDR;
+			s_formatHandlers[".jpg"] = &SaveJPEG;
+			s_formatHandlers[".jpeg"] = &SaveJPEG;
+			s_formatHandlers[".png"] = &SavePNG;
+			s_formatHandlers[".tga"] = &SaveTGA;
 
 			ImageSaver::Entry entry;
 			entry.formatSupport = FormatQuerier;


### PR DESCRIPTION
Supported file extensions **do not** include dot ('.') character like other format categories (e.g. OBJSaver), leading provided file extension (including dot ('.') character) to never match.

This PR adds missing dot ('.') character to STBSaver supported file extensions.