### PR TITLE
Integrate render target handling in frame graphs

### DIFF
--- a/include/Nazara/Graphics/ForwardFramePipeline.hpp
+++ b/include/Nazara/Graphics/ForwardFramePipeline.hpp
@@ -28,6 +28,7 @@
 #include <NazaraUtils/MemoryPool.hpp>
 #include <memory>
 #include <optional>
+#include <span>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -80,12 +81,14 @@ namespace Nz
 			ForwardFramePipeline& operator=(ForwardFramePipeline&&) = delete;
 
 		private:
+			struct ViewerData;
+
 			BakedFrameGraph BuildFrameGraph();
 
 			void RegisterMaterialInstance(MaterialInstance* materialPass);
 			void UnregisterMaterialInstance(MaterialInstance* material);
 
-			struct ViewerData;
+			static std::size_t BuildMergePass(FrameGraph& frameGraph, std::span<ViewerData*> targetViewers);
 
 			struct LightData
 			{
@@ -119,7 +122,6 @@ namespace Nz
 
 			struct RenderTargetData
 			{
-				std::size_t finalAttachment;
 				std::vector<const ViewerData*> viewers;
 			};
 

--- a/include/Nazara/Graphics/FrameGraph.hpp
+++ b/include/Nazara/Graphics/FrameGraph.hpp
@@ -15,6 +15,7 @@
 #include <Nazara/Graphics/FramePassAttachment.hpp>
 #include <Nazara/Renderer/Enums.hpp>
 #include <Nazara/Renderer/RenderPass.hpp>
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -26,6 +27,8 @@ namespace Nz
 {
 	class NAZARA_GRAPHICS_API FrameGraph
 	{
+		friend class BakedFrameGraph;
+
 		public:
 			FrameGraph() = default;
 			FrameGraph(const FrameGraph&) = delete;
@@ -38,6 +41,7 @@ namespace Nz
 			inline std::size_t AddAttachmentCube(FramePassAttachment attachment);
 			inline std::size_t AddAttachmentCubeFace(std::size_t attachmentId, CubemapFace face);
 			inline std::size_t AddAttachmentProxy(std::string name, std::size_t attachmentId);
+			inline std::size_t AddDummyAttachment();
 			inline FramePass& AddPass(std::string name);
 			inline void AddOutput(std::size_t attachmentIndex);
 
@@ -86,6 +90,10 @@ namespace Nz
 				MemoryAccessFlags access;
 				PipelineStageFlags stages;
 				TextureLayout layout;
+			};
+
+			struct DummyAttachment
+			{
 			};
 
 			struct PassBarriers
@@ -138,7 +146,10 @@ namespace Nz
 			void ReorderPasses();
 			void TraverseGraph(std::size_t passIndex);
 
-			using AttachmentType = std::variant<FramePassAttachment, AttachmentProxy, AttachmentArray, AttachmentCube, AttachmentLayer>;
+			using AttachmentType = std::variant<FramePassAttachment, AttachmentProxy, AttachmentArray, AttachmentCube, AttachmentLayer, DummyAttachment>;
+
+			static constexpr std::size_t InvalidAttachmentIndex = std::numeric_limits<std::size_t>::max();
+			static constexpr std::size_t InvalidTextureIndex = std::numeric_limits<std::size_t>::max();
 
 			std::vector<std::size_t> m_graphOutputs;
 			std::vector<FramePass> m_framePasses;

--- a/include/Nazara/Graphics/FrameGraph.inl
+++ b/include/Nazara/Graphics/FrameGraph.inl
@@ -78,6 +78,14 @@ namespace Nz
 		return id;
 	}
 
+	inline std::size_t FrameGraph::AddDummyAttachment()
+	{
+		std::size_t id = m_attachments.size();
+		m_attachments.emplace_back(DummyAttachment{});
+
+		return id;
+	}
+
 	inline FramePass& FrameGraph::AddPass(std::string name)
 	{
 		std::size_t id = m_framePasses.size();

--- a/include/Nazara/Graphics/FramePass.hpp
+++ b/include/Nazara/Graphics/FramePass.hpp
@@ -73,7 +73,9 @@ namespace Nz
 			inline void SetDepthStencilInput(std::size_t attachmentId);
 			inline void SetDepthStencilOutput(std::size_t attachmentId);
 			inline void SetExecutionCallback(ExecutionCallback callback);
-			inline void SetInputLayout(std::size_t inputIndex, TextureLayout layout);
+			inline void SetInputAccess(std::size_t inputIndex, TextureLayout layout, PipelineStageFlags stageFlags, MemoryAccessFlags accessFlags);
+			inline void SetInputAssumedLayout(std::size_t inputIndex, TextureLayout layout);
+			inline void SetInputUsage(std::size_t inputIndex, TextureUsageFlags usageFlags);
 			inline void SetReadInput(std::size_t inputIndex, bool doesRead);
 
 			FramePass& operator=(const FramePass&) = delete;
@@ -90,7 +92,11 @@ namespace Nz
 			struct Input
 			{
 				std::optional<TextureLayout> assumedLayout;
+				std::optional<TextureUsageFlags> textureUsageFlags;
 				std::size_t attachmentId;
+				MemoryAccessFlags accessFlags = MemoryAccess::ShaderRead;
+				PipelineStageFlags stageFlags = PipelineStage::FragmentShader;
+				TextureLayout layout = TextureLayout::ColorInput;
 				bool doesRead = true;
 			};
 

--- a/include/Nazara/Graphics/FramePass.inl
+++ b/include/Nazara/Graphics/FramePass.inl
@@ -127,10 +127,24 @@ namespace Nz
 		m_executionCallback = std::move(callback);
 	}
 
-	inline void FramePass::SetInputLayout(std::size_t inputIndex, TextureLayout layout)
+	inline void FramePass::SetInputAccess(std::size_t inputIndex, TextureLayout layout, PipelineStageFlags stageFlags, MemoryAccessFlags accessFlags)
+	{
+		assert(inputIndex < m_inputs.size());
+		m_inputs[inputIndex].accessFlags = accessFlags;
+		m_inputs[inputIndex].layout = layout;
+		m_inputs[inputIndex].stageFlags = stageFlags;
+	}
+
+	inline void FramePass::SetInputAssumedLayout(std::size_t inputIndex, TextureLayout layout)
 	{
 		assert(inputIndex < m_inputs.size());
 		m_inputs[inputIndex].assumedLayout = layout;
+	}
+
+	inline void FramePass::SetInputUsage(std::size_t inputIndex, TextureUsageFlags usageFlags)
+	{
+		assert(inputIndex < m_inputs.size());
+		m_inputs[inputIndex].textureUsageFlags = usageFlags;
 	}
 
 	inline void FramePass::SetReadInput(std::size_t inputIndex, bool doesRead)

--- a/include/Nazara/Graphics/RenderTarget.hpp
+++ b/include/Nazara/Graphics/RenderTarget.hpp
@@ -28,10 +28,14 @@ namespace Nz
 			inline RenderTarget(Int32 renderOrder = 0);
 			virtual ~RenderTarget();
 
-			virtual std::size_t OnBuildGraph(FrameGraph& frameGraph, std::size_t attachmentIndex) const = 0;
-
 			inline Int32 GetRenderOrder() const;
 			virtual const Vector2ui& GetSize() const = 0;
+
+			inline bool IsFrameGraphOutput() const;
+
+			virtual std::size_t OnBuildGraph(FrameGraph& frameGraph, std::size_t attachmentIndex) const = 0;
+
+			inline void SetFrameGraphOutput(bool output = true);
 
 			inline void UpdateRenderOrder(Int32 renderOrder);
 
@@ -41,6 +45,7 @@ namespace Nz
 
 		private:
 			Int32 m_renderOrder;
+			bool m_frameGraphOutput;
 	};
 }
 

--- a/include/Nazara/Graphics/RenderTarget.hpp
+++ b/include/Nazara/Graphics/RenderTarget.hpp
@@ -19,22 +19,28 @@ namespace Nz
 	class Framebuffer;
 	class FrameGraph;
 	class RenderPass;
-	class Texture;
 	class RenderResources;
+	class Texture;
 
 	class NAZARA_GRAPHICS_API RenderTarget
 	{
 		public:
-			RenderTarget() = default;
+			inline RenderTarget(Int32 renderOrder = 0);
 			virtual ~RenderTarget();
 
-			virtual void OnBuildGraph(FrameGraph& frameGraph, std::size_t attachmentIndex) const = 0;
-			virtual void OnRenderEnd(RenderResources& resources, const BakedFrameGraph& frameGraph, std::size_t finalAttachment) const = 0;
+			virtual std::size_t OnBuildGraph(FrameGraph& frameGraph, std::size_t attachmentIndex) const = 0;
 
+			inline Int32 GetRenderOrder() const;
 			virtual const Vector2ui& GetSize() const = 0;
 
+			inline void UpdateRenderOrder(Int32 renderOrder);
+
 			NazaraSignal(OnRenderTargetRelease, const RenderTarget* /*renderTarget*/);
+			NazaraSignal(OnRenderTargetRenderOrderChange, const RenderTarget* /*renderTarget*/, Int32 /*newOrder*/);
 			NazaraSignal(OnRenderTargetSizeChange, const RenderTarget* /*renderTarget*/, const Vector2ui& /*newSize*/);
+
+		private:
+			Int32 m_renderOrder;
 	};
 }
 

--- a/include/Nazara/Graphics/RenderTarget.inl
+++ b/include/Nazara/Graphics/RenderTarget.inl
@@ -6,6 +6,21 @@
 
 namespace Nz
 {
+	inline RenderTarget::RenderTarget(Int32 renderOrder) :
+	m_renderOrder(renderOrder)
+	{
+	}
+
+	inline Int32 RenderTarget::GetRenderOrder() const
+	{
+		return m_renderOrder;
+	}
+
+	inline void RenderTarget::UpdateRenderOrder(Int32 renderOrder)
+	{
+		OnRenderTargetRenderOrderChange(this, renderOrder);
+		m_renderOrder = renderOrder;
+	}
 }
 
 #include <Nazara/Graphics/DebugOff.hpp>

--- a/include/Nazara/Graphics/RenderTarget.inl
+++ b/include/Nazara/Graphics/RenderTarget.inl
@@ -7,13 +7,24 @@
 namespace Nz
 {
 	inline RenderTarget::RenderTarget(Int32 renderOrder) :
-	m_renderOrder(renderOrder)
+	m_renderOrder(renderOrder),
+	m_frameGraphOutput(false)
 	{
 	}
 
 	inline Int32 RenderTarget::GetRenderOrder() const
 	{
 		return m_renderOrder;
+	}
+
+	inline bool RenderTarget::IsFrameGraphOutput() const
+	{
+		return m_frameGraphOutput;
+	}
+
+	inline void RenderTarget::SetFrameGraphOutput(bool output)
+	{
+		m_frameGraphOutput = output;
 	}
 
 	inline void RenderTarget::UpdateRenderOrder(Int32 renderOrder)

--- a/include/Nazara/Graphics/RenderTexture.hpp
+++ b/include/Nazara/Graphics/RenderTexture.hpp
@@ -24,8 +24,7 @@ namespace Nz
 			RenderTexture(RenderTexture&&) = delete;
 			~RenderTexture() = default;
 
-			void OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const override;
-			void OnRenderEnd(RenderResources& resources, const BakedFrameGraph& frameGraph, std::size_t finalAttachment) const override;
+			std::size_t OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const override;
 
 			const Vector2ui& GetSize() const override;
 

--- a/include/Nazara/Graphics/RenderTextureBlit.hpp
+++ b/include/Nazara/Graphics/RenderTextureBlit.hpp
@@ -26,8 +26,7 @@ namespace Nz
 			RenderTextureBlit(RenderTextureBlit&&) = delete;
 			~RenderTextureBlit() = default;
 
-			void OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const override;
-			void OnRenderEnd(RenderResources& resources, const BakedFrameGraph& frameGraph, std::size_t finalAttachment) const override;
+			std::size_t OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const override;
 
 			const Vector2ui& GetSize() const override;
 

--- a/include/Nazara/Graphics/RenderWindow.hpp
+++ b/include/Nazara/Graphics/RenderWindow.hpp
@@ -25,13 +25,14 @@ namespace Nz
 			RenderWindow(RenderWindow&&) = delete;
 			~RenderWindow() = default;
 
-			void OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const override;
-			void OnRenderEnd(RenderResources& renderResources, const BakedFrameGraph& frameGraph, std::size_t attachmentId) const override;
+			std::size_t OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const override;
 
 			const Vector2ui& GetSize() const override;
 
 			RenderWindow& operator=(const RenderWindow&) = delete;
 			RenderWindow& operator=(RenderWindow&&) = delete;
+
+			static constexpr Int32 DefaultRenderOrder = 1000;
 
 		private:
 			void SetSwapchain(Swapchain* swapchain);

--- a/include/Nazara/Graphics/RenderWindow.inl
+++ b/include/Nazara/Graphics/RenderWindow.inl
@@ -7,6 +7,7 @@
 namespace Nz
 {
 	inline RenderWindow::RenderWindow(Swapchain& swapchain) :
+	RenderTarget(DefaultRenderOrder),
 	m_swapchain(&swapchain),
 	m_windowSwapchain(nullptr)
 	{

--- a/src/Nazara/Graphics/BakedFrameGraph.cpp
+++ b/src/Nazara/Graphics/BakedFrameGraph.cpp
@@ -248,7 +248,7 @@ namespace Nz
 					passData.framebuffer->UpdateDebugName(passData.name);
 			}
 			else
-				passData.renderRect = Recti(0, 0, int(-1), int(-1));
+				passData.renderRect = Recti(0, 0, -1, -1);
 
 			passData.forceCommandBufferRegeneration = true;
 		}

--- a/src/Nazara/Graphics/BakedFrameGraph.cpp
+++ b/src/Nazara/Graphics/BakedFrameGraph.cpp
@@ -3,9 +3,9 @@
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
 #include <Nazara/Graphics/BakedFrameGraph.hpp>
+#include <Nazara/Graphics/FrameGraph.hpp>
 #include <Nazara/Graphics/Graphics.hpp>
 #include <Nazara/Renderer/CommandBufferBuilder.hpp>
-#include <Nazara/Renderer/RenderFrame.hpp>
 #include <Nazara/Graphics/Debug.hpp>
 
 namespace Nz
@@ -60,7 +60,8 @@ namespace Nz
 					builder.TextureBarrier(textureTransition.srcStageMask, textureTransition.dstStageMask, textureTransition.srcAccessMask, textureTransition.dstAccessMask, textureTransition.oldLayout, textureTransition.newLayout, *texture);
 				}
 
-				builder.BeginRenderPass(*passData.framebuffer, *passData.renderPass, passData.renderRect, passData.outputClearValues.data(), passData.outputClearValues.size());
+				if (passData.framebuffer)
+					builder.BeginRenderPass(*passData.framebuffer, *passData.renderPass, passData.renderRect, passData.outputClearValues.data(), passData.outputClearValues.size());
 
 				if (!passData.name.empty())
 					builder.BeginDebugRegion(passData.name, Color::Green());
@@ -85,7 +86,8 @@ namespace Nz
 				if (!passData.name.empty())
 					builder.EndDebugRegion();
 
-				builder.EndRenderPass();
+				if (passData.framebuffer)
+					builder.EndRenderPass();
 			});
 
 			passData.forceCommandBufferRegeneration = false;
@@ -102,7 +104,7 @@ namespace Nz
 	const std::shared_ptr<Texture>& BakedFrameGraph::GetAttachmentTexture(std::size_t attachmentIndex) const
 	{
 		auto it = m_attachmentToTextureMapping.find(attachmentIndex);
-		if (it == m_attachmentToTextureMapping.end())
+		if (it == m_attachmentToTextureMapping.end() || it->second == FrameGraph::InvalidTextureIndex)
 		{
 			static std::shared_ptr<Texture> dummy;
 			return dummy;
@@ -116,7 +118,7 @@ namespace Nz
 	const std::shared_ptr<RenderPass>& BakedFrameGraph::GetRenderPass(std::size_t passIndex) const
 	{
 		auto it = m_attachmentToTextureMapping.find(passIndex);
-		if (it == m_attachmentToTextureMapping.end())
+		if (it == m_attachmentToTextureMapping.end() || it->second == FrameGraph::InvalidTextureIndex)
 		{
 			static std::shared_ptr<RenderPass> dummy;
 			return dummy;
@@ -224,24 +226,29 @@ namespace Nz
 		{
 			textures.clear();
 
-			unsigned int framebufferWidth = std::numeric_limits<unsigned int>::max();
-			unsigned int framebufferHeight = std::numeric_limits<unsigned int>::max();
-			for (std::size_t textureId : passData.outputTextureIndices)
+			if (!passData.outputTextureIndices.empty())
 			{
-				auto& textureData = m_textures[textureId];
-				textures.push_back(textureData.texture);
+				unsigned int framebufferWidth = std::numeric_limits<unsigned int>::max();
+				unsigned int framebufferHeight = std::numeric_limits<unsigned int>::max();
+				for (std::size_t textureId : passData.outputTextureIndices)
+				{
+					auto& textureData = m_textures[textureId];
+					textures.push_back(textureData.texture);
 
-				auto [width, height] = ComputeTextureSize(textureData);
+					auto [width, height] = ComputeTextureSize(textureData);
 
-				framebufferWidth = std::min(framebufferWidth, width);
-				framebufferHeight = std::min(framebufferHeight, height);
+					framebufferWidth = std::min(framebufferWidth, width);
+					framebufferHeight = std::min(framebufferHeight, height);
+				}
+
+				passData.renderRect = Recti(0, 0, int(framebufferWidth), int(framebufferHeight));
+
+				passData.framebuffer = renderDevice->InstantiateFramebuffer(framebufferWidth, framebufferHeight, passData.renderPass, textures);
+				if (!passData.name.empty())
+					passData.framebuffer->UpdateDebugName(passData.name);
 			}
-
-			passData.renderRect = Recti(0, 0, int(framebufferWidth), int(framebufferHeight));
-
-			passData.framebuffer = renderDevice->InstantiateFramebuffer(framebufferWidth, framebufferHeight, passData.renderPass, textures);
-			if (!passData.name.empty())
-				passData.framebuffer->UpdateDebugName(passData.name);
+			else
+				passData.renderRect = Recti(0, 0, int(-1), int(-1));
 
 			passData.forceCommandBufferRegeneration = true;
 		}

--- a/src/Nazara/Graphics/DirectionalLightShadowData.cpp
+++ b/src/Nazara/Graphics/DirectionalLightShadowData.cpp
@@ -217,7 +217,7 @@ namespace Nz
 		PerViewerData& viewerData = *Retrieve(m_viewerData, viewer);
 
 		std::size_t arrayInputIndex = pass.AddInput(viewerData.textureArrayAttachmentIndex);
-		pass.SetInputLayout(arrayInputIndex, TextureLayout::ColorInput);
+		pass.SetInputAssumedLayout(arrayInputIndex, TextureLayout::ColorInput);
 
 		for (CascadeData& cascade : viewerData.cascades)
 			pass.AddInput(cascade.attachmentIndex);

--- a/src/Nazara/Graphics/ForwardFramePipeline.cpp
+++ b/src/Nazara/Graphics/ForwardFramePipeline.cpp
@@ -714,8 +714,13 @@ namespace Nz
 				finalAttachment = renderTarget.OnBuildGraph(frameGraph, viewer.finalColorAttachment);
 			}
 
-			// Keep track of previous dependencies attachments
-			dependenciesColorAttachments.push_back(finalAttachment);
+			if (!renderTarget.IsFrameGraphOutput())
+			{
+				// Keep track of previous dependencies attachments
+				dependenciesColorAttachments.push_back(finalAttachment);
+			}
+			else
+				frameGraph.AddOutput(finalAttachment);
 		};
 
 		const RenderTarget* currentTarget = &m_orderedViewers.front()->viewer->GetRenderTarget();

--- a/src/Nazara/Graphics/ForwardFramePipeline.cpp
+++ b/src/Nazara/Graphics/ForwardFramePipeline.cpp
@@ -383,21 +383,26 @@ namespace Nz
 		}
 
 		frameGraphInvalidated |= m_bakedFrameGraph.Resize(renderResources, viewerSizes);
+		if (frameGraphInvalidated)
+		{
+			for (ViewerData& viewerData : m_viewerPool)
+			{
+				if (viewerData.blitShaderBinding)
+					renderResources.PushForRelease(std::move(viewerData.blitShaderBinding));
+			}
+		}
 
 		// Find active lights (i.e. visible in any frustum)
 		m_activeLights.Clear();
-		for (auto& viewerData : m_viewerPool)
+		for (ViewerData* viewerData : m_orderedViewers)
 		{
-			if (viewerData.pendingDestruction)
-				continue;
-
-			UInt32 renderMask = viewerData.viewer->GetRenderMask();
+			UInt32 renderMask = viewerData->viewer->GetRenderMask();
 
 			// Extract frustum from viewproj matrix
-			const Matrix4f& viewProjMatrix = viewerData.viewer->GetViewerInstance().GetViewProjMatrix();
-			viewerData.frame.frustum = Frustumf::Extract(viewProjMatrix);
+			const Matrix4f& viewProjMatrix = viewerData->viewer->GetViewerInstance().GetViewProjMatrix();
+			viewerData->frame.frustum = Frustumf::Extract(viewProjMatrix);
 
-			viewerData.frame.visibleLights.Clear();
+			viewerData->frame.visibleLights.Clear();
 			for (auto it = m_lightPool.begin(); it != m_lightPool.end(); ++it)
 			{
 				const LightData& lightData = *it;
@@ -407,7 +412,7 @@ namespace Nz
 					continue;
 
 				m_activeLights.UnboundedSet(lightIndex);
-				viewerData.frame.visibleLights.UnboundedSet(lightIndex);
+				viewerData->frame.visibleLights.UnboundedSet(lightIndex);
 			}
 		}
 
@@ -422,59 +427,32 @@ namespace Nz
 		}
 
 		// Viewer handling (second pass)
-		for (auto& viewerData : m_viewerPool)
+		for (ViewerData* viewerData : m_orderedViewers)
 		{
-			if (viewerData.pendingDestruction)
-				continue;
-
-			UInt32 renderMask = viewerData.viewer->GetRenderMask();
+			UInt32 renderMask = viewerData->viewer->GetRenderMask();
 
 			// Per-viewer shadow map handling
-			for (std::size_t lightIndex : viewerData.frame.visibleLights.IterBits())
+			for (std::size_t lightIndex : viewerData->frame.visibleLights.IterBits())
 			{
 				LightData* lightData = m_lightPool.RetrieveFromIndex(lightIndex);
 				if (lightData->shadowData && lightData->shadowData->IsPerViewer() && (renderMask & lightData->renderMask) != 0)
-					lightData->shadowData->PrepareRendering(renderResources, viewerData.viewer);
+					lightData->shadowData->PrepareRendering(renderResources, viewerData->viewer);
 			}
 
 			// Frustum culling
 			std::size_t visibilityHash = 5;
-			const auto& visibleRenderables = FrustumCull(viewerData.frame.frustum, renderMask, visibilityHash);
+			const auto& visibleRenderables = FrustumCull(viewerData->frame.frustum, renderMask, visibilityHash);
 
 			FramePipelinePass::FrameData passData = {
-				&viewerData.frame.visibleLights,
-				viewerData.frame.frustum,
+				&viewerData->frame.visibleLights,
+				viewerData->frame.frustum,
 				renderResources,
 				visibleRenderables,
 				visibilityHash
 			};
 
-			for (auto& passPtr : viewerData.passes)
+			for (auto& passPtr : viewerData->passes)
 				passPtr->Prepare(passData);
-		}
-
-		if (frameGraphInvalidated)
-		{
-			const std::shared_ptr<TextureSampler>& sampler = graphics->GetSamplerCache().Get({});
-			for (auto& viewerData : m_viewerPool)
-			{
-				if (viewerData.pendingDestruction)
-					continue;
-
-				if (viewerData.blitShaderBinding)
-					renderResources.PushForRelease(std::move(viewerData.blitShaderBinding));
-
-				viewerData.blitShaderBinding = graphics->GetBlitPipelineLayout()->AllocateShaderBinding(0);
-				viewerData.blitShaderBinding->Update({
-					{
-						0,
-						ShaderBinding::SampledTextureBinding {
-							m_bakedFrameGraph.GetAttachmentTexture(viewerData.finalColorAttachment).get(),
-							sampler.get()
-						}
-					}
-				});
-			}
 		}
 
 		// Update UBOs and materials
@@ -497,10 +475,6 @@ namespace Nz
 
 		m_bakedFrameGraph.Execute(renderResources);
 		m_rebuildFrameGraph = false;
-
-		// Final blit (TODO: Make part of frame graph?)
-		for (auto&& [renderTargetPtr, renderTargetData] : m_renderTargets)
-			renderTargetPtr->OnRenderEnd(renderResources, m_bakedFrameGraph, renderTargetData.finalAttachment);
 
 		// reset at the end instead of the beginning so debug draw can be used before calling this method
 		DebugDrawer& debugDrawer = GetDebugDrawer();
@@ -648,6 +622,7 @@ namespace Nz
 	{
 		FrameGraph frameGraph;
 
+		// Register viewer-independent passes
 		for (std::size_t i : m_shadowCastingLights.IterBits())
 		{
 			LightData* lightData = m_lightPool.RetrieveFromIndex(i);
@@ -655,147 +630,170 @@ namespace Nz
 				lightData->shadowData->RegisterToFrameGraph(frameGraph, nullptr);
 		}
 
-		using ViewerPair = std::pair<const RenderTarget*, ViewerData*>;
-
-		StackArray<ViewerPair> viewers = NazaraStackArray(ViewerPair, m_viewerPool.size());
-		auto viewerIt = viewers.begin();
-
+		// Group every viewer by their render order and RenderTarget
+		m_orderedViewers.clear();
 		for (auto& viewerData : m_viewerPool)
 		{
 			if (viewerData.pendingDestruction)
 				continue;
 
-			const RenderTarget& renderTarget = viewerData.viewer->GetRenderTarget();
-			*viewerIt++ = std::make_pair(&renderTarget, &viewerData);
+			m_orderedViewers.push_back(&viewerData);
 		}
 
-		std::sort(viewers.begin(), viewers.end(), [](const ViewerPair& lhs, const ViewerPair& rhs)
+		if (m_orderedViewers.empty())
+			return frameGraph.Bake();
+
+		std::sort(m_orderedViewers.begin(), m_orderedViewers.end(), [](ViewerData* lhs, ViewerData* rhs)
 		{
-			return lhs.second->renderOrder < rhs.second->renderOrder;
+			// Order by RenderTarget render order and then by viewer render order
+			Int32 leftTargetRenderOrder1 = lhs->viewer->GetRenderTarget().GetRenderOrder();
+			Int32 rightTargetRenderOrder1 = rhs->viewer->GetRenderTarget().GetRenderOrder();
+
+			if (leftTargetRenderOrder1 == rightTargetRenderOrder1)
+				return leftTargetRenderOrder1 < rightTargetRenderOrder1;
+			else
+				return lhs->renderOrder < rhs->renderOrder;
 		});
 
-		StackVector<std::size_t> dependenciesColorAttachments = NazaraStackVector(std::size_t, viewers.size());
+		StackVector<std::size_t> dependenciesColorAttachments = NazaraStackVector(std::size_t, m_orderedViewers.size());
+		std::size_t dependenciesColorAttachmentCount = 0;
+		Int32 lastRenderOrder = m_orderedViewers.front()->viewer->GetRenderTarget().GetRenderOrder();
 
-		m_orderedViewers.clear();
-		m_renderTargets.clear();
-		unsigned int viewerIndex = 0;
-		for (auto it = viewers.begin(), prevIt = it; it != viewers.end(); ++it)
+		std::size_t viewerIndex = 0;
+		auto HandleRenderTarget = [&](const RenderTarget& renderTarget, std::span<ViewerData*> viewers)
 		{
-			auto&& [renderTarget, viewerData] = *it;
-
-			UInt32 renderMask = viewerData->viewer->GetRenderMask();
-			for (std::size_t i : m_shadowCastingLights.IterBits())
+			if (renderTarget.GetRenderOrder() > lastRenderOrder)
 			{
-				LightData* lightData = m_lightPool.RetrieveFromIndex(i);
-				if (lightData->shadowData->IsPerViewer() && (renderMask & lightData->renderMask) != 0)
-					lightData->shadowData->RegisterToFrameGraph(frameGraph, viewerData->viewer);
+				dependenciesColorAttachmentCount = dependenciesColorAttachments.size();
+				lastRenderOrder = renderTarget.GetRenderOrder();
 			}
 
-			// Keep track of previous dependencies attachments (from viewers having a smaller render order)
-			Int32 renderOrder = viewerData->renderOrder;
-			for (auto it2 = prevIt; prevIt != it; ++prevIt)
-			{
-				ViewerData* prevViewerData = prevIt->second;
-				Int32 prevRenderOrder = prevViewerData->renderOrder;
-				if (prevRenderOrder >= renderOrder)
-					break;
+			assert(!viewers.empty());
 
-				dependenciesColorAttachments.push_back(prevViewerData->finalColorAttachment);
-				prevIt = it2;
-			}
-
-			auto framePassCallback = [&, viewerData = viewerData](std::size_t /*passIndex*/, FramePass& framePass, FramePipelinePassFlags flags)
+			for (ViewerData* viewerData : viewers)
 			{
-				// Inject previous final attachments as inputs for all passes, to force framegraph to order viewers passes relative to each other
-				// TODO: Allow the user to define which pass of viewer A uses viewer B rendering
-				for (std::size_t finalAttachment : dependenciesColorAttachments)
+				UInt32 renderMask = viewerData->viewer->GetRenderMask();
+				for (std::size_t i : m_shadowCastingLights.IterBits())
 				{
-					std::size_t inputIndex = framePass.AddInput(finalAttachment);
-
-					// Disable ReadInput to prevent the framegraph from transitionning the texture layout (for now it's handled externally)
-					// (however if we manage to get rid of the texture blit from RenderTexture by making the framegraph use the external texture directly, this would be necessary)
-					framePass.SetReadInput(inputIndex, false);
+					LightData* lightData = m_lightPool.RetrieveFromIndex(i);
+					if (lightData->shadowData->IsPerViewer() && (renderMask & lightData->renderMask) != 0)
+						lightData->shadowData->RegisterToFrameGraph(frameGraph, viewerData->viewer);
 				}
 
-				if (flags.Test(FramePipelinePassFlag::LightShadowing))
+				auto framePassCallback = [&, viewerData = viewerData](std::size_t /*passIndex*/, FramePass& framePass, FramePipelinePassFlags flags)
 				{
-					for (std::size_t i : m_shadowCastingLights.IterBits())
+					// Inject previous final attachments as inputs for all passes, to force framegraph to order viewers passes relative to each other
+					// TODO: Allow the user to define which pass of viewer A uses viewer B rendering
+					for (std::size_t i = 0; i < dependenciesColorAttachmentCount; ++i)
+						framePass.AddInput(dependenciesColorAttachments[i]);
+
+					if (flags.Test(FramePipelinePassFlag::LightShadowing))
 					{
-						LightData* lightData = m_lightPool.RetrieveFromIndex(i);
-						if ((renderMask & lightData->renderMask) != 0)
-							lightData->shadowData->RegisterPassInputs(framePass, (lightData->shadowData->IsPerViewer()) ? viewerData->viewer : nullptr);
-					}
-				}
-			};
-
-			viewerData->finalColorAttachment = viewerData->viewer->RegisterPasses(viewerData->passes, frameGraph, viewerIndex++, framePassCallback);
-
-			// Group viewers by render targets
-			auto& renderTargetData = m_renderTargets[renderTarget];
-			renderTargetData.viewers.push_back(viewerData);
-			m_orderedViewers.push_back(viewerData);
-		}
-
-		for (auto&& [renderTarget, renderTargetData] : m_renderTargets)
-		{
-			const auto& targetViewers = renderTargetData.viewers;
-
-			if (targetViewers.size() > 1)
-			{
-				// Multiple viewers on the same targets, merge them
-				FramePass& mergePass = frameGraph.AddPass("Merge pass");
-
-				renderTargetData.finalAttachment = frameGraph.AddAttachment({
-					"Viewer output",
-					PixelFormat::RGBA8
-				});
-
-				for (const ViewerData* viewerData : targetViewers)
-					mergePass.AddInput(viewerData->finalColorAttachment);
-
-				mergePass.AddOutput(renderTargetData.finalAttachment);
-				mergePass.SetClearColor(0, Color::Black());
-
-				mergePass.SetCommandCallback([&targetViewers](CommandBufferBuilder& builder, const FramePassEnvironment& /*env*/)
-				{
-					Graphics* graphics = Graphics::Instance();
-					builder.BindRenderPipeline(*graphics->GetBlitPipeline(false));
-
-					bool first = true;
-
-					for (const ViewerData* viewerData : targetViewers)
-					{
-						Recti renderRect = viewerData->viewer->GetViewport();
-
-						builder.SetScissor(renderRect);
-						builder.SetViewport(renderRect);
-
-						const ShaderBindingPtr& blitShaderBinding = viewerData->blitShaderBinding;
-
-						builder.BindRenderShaderBinding(0, *blitShaderBinding);
-						builder.Draw(3);
-
-						if (first)
+						for (std::size_t i : m_shadowCastingLights.IterBits())
 						{
-							builder.BindRenderPipeline(*graphics->GetBlitPipeline(true));
-							first = false;
+							LightData* lightData = m_lightPool.RetrieveFromIndex(i);
+							if ((renderMask & lightData->renderMask) != 0)
+								lightData->shadowData->RegisterPassInputs(framePass, (lightData->shadowData->IsPerViewer()) ? viewerData->viewer : nullptr);
 						}
 					}
-				});
+				};
 
-				renderTarget->OnBuildGraph(frameGraph, renderTargetData.finalAttachment);
+				viewerData->finalColorAttachment = viewerData->viewer->RegisterPasses(viewerData->passes, frameGraph, viewerIndex++, framePassCallback);
 			}
-			else if (targetViewers.size() == 1)
+
+			std::size_t finalAttachment;
+			if (viewers.size() > 1)
+			{
+				// Multiple viewers on the same targets, merge them
+				finalAttachment = renderTarget.OnBuildGraph(frameGraph, BuildMergePass(frameGraph, viewers));
+			}
+			else
 			{
 				// Single viewer on that target
-				const auto& viewer = *targetViewers.front();
+				const auto& viewer = *viewers.front();
+				finalAttachment = renderTarget.OnBuildGraph(frameGraph, viewer.finalColorAttachment);
+			}
 
-				renderTargetData.finalAttachment = viewer.finalColorAttachment;
-				renderTarget->OnBuildGraph(frameGraph, renderTargetData.finalAttachment);
+			// Keep track of previous dependencies attachments
+			dependenciesColorAttachments.push_back(finalAttachment);
+		};
+
+		const RenderTarget* currentTarget = &m_orderedViewers.front()->viewer->GetRenderTarget();
+		std::size_t currentTargetIndex = 0;
+		for (std::size_t i = 1; i < m_orderedViewers.size(); ++i)
+		{
+			const RenderTarget* target = &m_orderedViewers[i]->viewer->GetRenderTarget();
+			if (currentTarget != target)
+			{
+				HandleRenderTarget(*currentTarget, std::span(&m_orderedViewers[currentTargetIndex], &m_orderedViewers[i]));
+				currentTarget = target;
+				currentTargetIndex = i;
 			}
 		}
+		HandleRenderTarget(*currentTarget, std::span(m_orderedViewers.begin() + currentTargetIndex, m_orderedViewers.end()));
 
 		return frameGraph.Bake();
+	}
+
+	std::size_t ForwardFramePipeline::BuildMergePass(FrameGraph& frameGraph, std::span<ViewerData*> targetViewers)
+	{
+		FramePass& mergePass = frameGraph.AddPass("Merge pass");
+
+		std::size_t mergedAttachment = frameGraph.AddAttachment({
+			"Merged output",
+			PixelFormat::RGBA8
+		});
+
+		for (const ViewerData* viewerData : targetViewers)
+			mergePass.AddInput(viewerData->finalColorAttachment);
+
+		mergePass.AddOutput(mergedAttachment);
+		mergePass.SetClearColor(0, Color::Black());
+
+		mergePass.SetCommandCallback([&targetViewers](CommandBufferBuilder& builder, const FramePassEnvironment& env)
+		{
+			Graphics* graphics = Graphics::Instance();
+			builder.BindRenderPipeline(*graphics->GetBlitPipeline(false));
+
+			bool first = true;
+
+			for (ViewerData* viewerData : targetViewers)
+			{
+				Recti renderRect = viewerData->viewer->GetViewport();
+
+				builder.SetScissor(renderRect);
+				builder.SetViewport(renderRect);
+
+				if (!viewerData->blitShaderBinding)
+				{
+					const std::shared_ptr<TextureSampler>& sampler = graphics->GetSamplerCache().Get({});
+
+					viewerData->blitShaderBinding = graphics->GetBlitPipelineLayout()->AllocateShaderBinding(0);
+					viewerData->blitShaderBinding->Update({
+						{
+							0,
+							ShaderBinding::SampledTextureBinding {
+								env.frameGraph.GetAttachmentTexture(viewerData->finalColorAttachment).get(),
+								sampler.get()
+							}
+						}
+					});
+				}
+
+				const ShaderBindingPtr& blitShaderBinding = viewerData->blitShaderBinding;
+
+				builder.BindRenderShaderBinding(0, *blitShaderBinding);
+				builder.Draw(3);
+
+				if (first)
+				{
+					builder.BindRenderPipeline(*graphics->GetBlitPipeline(true));
+					first = false;
+				}
+			}
+		});
+
+		return mergedAttachment;
 	}
 
 	void ForwardFramePipeline::RegisterMaterialInstance(MaterialInstance* materialInstance)

--- a/src/Nazara/Graphics/ForwardFramePipeline.cpp
+++ b/src/Nazara/Graphics/ForwardFramePipeline.cpp
@@ -730,7 +730,7 @@ namespace Nz
 				currentTargetIndex = i;
 			}
 		}
-		HandleRenderTarget(*currentTarget, std::span(m_orderedViewers.begin() + currentTargetIndex, m_orderedViewers.end()));
+		HandleRenderTarget(*currentTarget, std::span(m_orderedViewers.data() + currentTargetIndex, m_orderedViewers.data() + m_orderedViewers.size()));
 
 		return frameGraph.Bake();
 	}

--- a/src/Nazara/Graphics/PointLightShadowData.cpp
+++ b/src/Nazara/Graphics/PointLightShadowData.cpp
@@ -135,7 +135,7 @@ namespace Nz
 		assert(viewer == nullptr);
 
 		std::size_t cubeInputIndex = pass.AddInput(m_cubeAttachmentIndex);
-		pass.SetInputLayout(cubeInputIndex, TextureLayout::ColorInput);
+		pass.SetInputAssumedLayout(cubeInputIndex, TextureLayout::ColorInput);
 
 		for (DirectionData& direction : m_directions)
 			pass.AddInput(direction.attachmentIndex);

--- a/src/Nazara/Graphics/RenderTexture.cpp
+++ b/src/Nazara/Graphics/RenderTexture.cpp
@@ -15,13 +15,10 @@ namespace Nz
 	{
 	}
 
-	void RenderTexture::OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const
+	std::size_t RenderTexture::OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const
 	{
 		graph.BindExternalTexture(attachmentIndex, m_targetTexture);
-	}
-
-	void RenderTexture::OnRenderEnd(RenderResources& /*renderFrame*/, const BakedFrameGraph& /*frameGraph*/, std::size_t /*finalAttachment*/) const
-	{
+		return attachmentIndex;
 	}
 
 	const Vector2ui& RenderTexture::GetSize() const

--- a/src/Nazara/Graphics/RenderWindow.cpp
+++ b/src/Nazara/Graphics/RenderWindow.cpp
@@ -29,11 +29,13 @@ namespace Nz
 			SetSwapchain(nullptr);
 		});
 
+		SetFrameGraphOutput(true);
 		SetSwapchain(m_windowSwapchain->GetSwapchain());
 	}
 
 	std::size_t RenderWindow::OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const
 	{
+		// TODO: Replace the blit to swapchain by a graph.BindExternalSwapchain?
 		std::size_t linkAttachment = graph.AddDummyAttachment();
 		
 		FramePass& blitPass = graph.AddPass("Blit to swapchain");
@@ -60,7 +62,6 @@ namespace Nz
 			builder.BlitTextureToSwapchain(*sourceTexture, blitRegion, TextureLayout::TransferSource, *m_swapchain, env.renderResources.GetImageIndex());
 		});
 
-		graph.AddOutput(linkAttachment);
 		return linkAttachment;
 	}
 

--- a/src/Nazara/Graphics/RenderWindow.cpp
+++ b/src/Nazara/Graphics/RenderWindow.cpp
@@ -15,6 +15,7 @@
 namespace Nz
 {
 	RenderWindow::RenderWindow(WindowSwapchain& swapchain) :
+	RenderTarget(DefaultRenderOrder),
 	m_swapchain(nullptr),
 	m_windowSwapchain(&swapchain)
 	{
@@ -31,27 +32,36 @@ namespace Nz
 		SetSwapchain(m_windowSwapchain->GetSwapchain());
 	}
 
-	void RenderWindow::OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const
+	std::size_t RenderWindow::OnBuildGraph(FrameGraph& graph, std::size_t attachmentIndex) const
 	{
-		graph.AddOutput(attachmentIndex);
-	}
+		std::size_t linkAttachment = graph.AddDummyAttachment();
+		
+		FramePass& blitPass = graph.AddPass("Blit to swapchain");
+		blitPass.AddInput(attachmentIndex);
+		blitPass.SetInputAccess(0, TextureLayout::TransferSource, PipelineStage::Transfer, MemoryAccess::MemoryRead);
+		blitPass.SetInputUsage(0, TextureUsage::TransferSource);
 
-	void RenderWindow::OnRenderEnd(RenderResources& renderResources, const BakedFrameGraph& frameGraph, std::size_t finalAttachment) const
-	{
-		const std::shared_ptr<Texture>& texture = frameGraph.GetAttachmentTexture(finalAttachment);
+		blitPass.AddOutput(linkAttachment);
 
-		Vector2ui textureSize = Vector2ui(texture->GetSize());
-		Boxui blitRegion(0, 0, 0, textureSize.x, textureSize.y, 1);
-
-		renderResources.Execute([&](CommandBufferBuilder& builder)
+		// Force regeneration of RenderWindow execution callback (since image index changes every frame)
+		// TODO: Maybe handle this in a better way (temporary command buffer? multiple commands buffers selected by frame index?)
+		blitPass.SetExecutionCallback([]
 		{
-			builder.BeginDebugRegion("Blit to swapchain", Color::Blue());
-			{
-				builder.TextureBarrier(PipelineStage::ColorOutput, PipelineStage::Transfer, MemoryAccess::ColorWrite, MemoryAccess::TransferRead, TextureLayout::ColorOutput, TextureLayout::TransferSource, *texture);
-				builder.BlitTextureToSwapchain(*texture, blitRegion, TextureLayout::TransferSource, *m_swapchain, renderResources.GetImageIndex());
-			}
-			builder.EndDebugRegion();
-		}, QueueType::Graphics);
+			return FramePassExecution::UpdateAndExecute;
+		});
+
+		blitPass.SetCommandCallback([this, attachmentIndex](CommandBufferBuilder& builder, const FramePassEnvironment& env)
+		{
+			const std::shared_ptr<Texture>& sourceTexture = env.frameGraph.GetAttachmentTexture(attachmentIndex);
+
+			Vector2ui textureSize = Vector2ui(sourceTexture->GetSize());
+			Boxui blitRegion(0, 0, 0, textureSize.x, textureSize.y, 1);
+
+			builder.BlitTextureToSwapchain(*sourceTexture, blitRegion, TextureLayout::TransferSource, *m_swapchain, env.renderResources.GetImageIndex());
+		});
+
+		graph.AddOutput(linkAttachment);
+		return linkAttachment;
 	}
 
 	const Vector2ui& RenderWindow::GetSize() const


### PR DESCRIPTION
- This handles the blit to texture/swapchain in the FrameGraph and fixes RenderTextureBlit
- Dummy attachments were added to the FrameGraph class to handle link without texture (used to setup a dependency between two passes with no texture)
- FramePass now supports custom access/layout/usage for inputs