### PR TITLE
Optimize out a lot of std::string construction and allocations

### DIFF
--- a/include/Nazara/Core/CommandLineParameters.hpp
+++ b/include/Nazara/Core/CommandLineParameters.hpp
@@ -8,9 +8,8 @@
 #define NAZARA_CORE_COMMANDLINEPARAMETERS_HPP
 
 #include <NazaraUtils/Prerequisites.hpp>
-#include <NazaraUtils/Algorithm.hpp>
-#include <string>
-#include <string_view>
+#include <NazaraUtils/StringHash.hpp>
+#include <NazaraUtils/TypeTraits.hpp>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -19,9 +18,9 @@ namespace Nz
 	class CommandLineParameters
 	{
 		public:
-			inline bool GetParameter(const std::string& name, std::string_view* value) const;
+			inline bool GetParameter(std::string_view name, std::string_view* value) const;
 
-			inline bool HasFlag(const std::string& flag) const;
+			inline bool HasFlag(std::string_view flag) const;
 
 			inline bool operator==(const CommandLineParameters& params) const;
 			inline bool operator!=(const CommandLineParameters& params) const;
@@ -30,8 +29,8 @@ namespace Nz
 			static inline CommandLineParameters Parse(int argc, const Pointer<const char>* argv);
 
 		private:
-			std::unordered_map<std::string, std::string> m_parameters;
-			std::unordered_set<std::string> m_flags;
+			std::unordered_map<std::string, std::string, StringHash<>, std::equal_to<>> m_parameters;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_flags;
 	};
 }
 

--- a/include/Nazara/Core/CommandLineParameters.inl
+++ b/include/Nazara/Core/CommandLineParameters.inl
@@ -6,7 +6,7 @@
 
 namespace Nz
 {
-	inline bool CommandLineParameters::GetParameter(const std::string& name, std::string_view* value) const
+	inline bool CommandLineParameters::GetParameter(std::string_view name, std::string_view* value) const
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -18,9 +18,9 @@ namespace Nz
 		return true;
 	}
 
-	inline bool CommandLineParameters::HasFlag(const std::string& flag) const
+	inline bool CommandLineParameters::HasFlag(std::string_view flag) const
 	{
-		return m_flags.find(flag) != m_flags.end();
+		return m_flags.contains(flag);
 	}
 
 	inline bool CommandLineParameters::operator==(const CommandLineParameters& params) const

--- a/include/Nazara/Core/ObjectLibrary.hpp
+++ b/include/Nazara/Core/ObjectLibrary.hpp
@@ -7,6 +7,8 @@
 #ifndef NAZARA_CORE_OBJECTLIBRARY_HPP
 #define NAZARA_CORE_OBJECTLIBRARY_HPP
 
+#include <NazaraUtils/StringHash.hpp>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -24,15 +26,15 @@ namespace Nz
 
 			void Clear();
 
-			std::shared_ptr<Type> Get(const std::string& name);
-			bool Has(const std::string& name);
+			std::shared_ptr<Type> Get(std::string_view name);
+			bool Has(std::string_view name);
 
-			void Register(const std::string& name, std::shared_ptr<Type> object);
-			std::shared_ptr<Type> Query(const std::string& name);
-			void Unregister(const std::string& name);
+			void Register(std::string name, std::shared_ptr<Type> object);
+			std::shared_ptr<Type> Query(std::string_view name);
+			void Unregister(std::string_view name);
 
 		private:
-			std::unordered_map<std::string, std::shared_ptr<Type>> m_library;
+			std::unordered_map<std::string, std::shared_ptr<Type>, StringHash<>, std::equal_to<>> m_library;
 	};
 }
 

--- a/include/Nazara/Core/ObjectLibrary.inl
+++ b/include/Nazara/Core/ObjectLibrary.inl
@@ -31,7 +31,7 @@ namespace Nz
 	* \remark Produces a NazaraError if object not found
 	*/
 	template<typename Type>
-	std::shared_ptr<Type> ObjectLibrary<Type>::Get(const std::string& name)
+	std::shared_ptr<Type> ObjectLibrary<Type>::Get(std::string_view name)
 	{
 		std::shared_ptr<Type> ref = Query(name);
 		if (!ref)
@@ -45,9 +45,9 @@ namespace Nz
 	* \return true if it the case
 	*/
 	template<typename Type>
-	bool ObjectLibrary<Type>::Has(const std::string& name)
+	bool ObjectLibrary<Type>::Has(std::string_view name)
 	{
-		return m_library.find(name) != m_library.end();
+		return m_library.contains(name);
 	}
 
 	/*!
@@ -57,9 +57,9 @@ namespace Nz
 	* \param object Object to stock
 	*/
 	template<typename Type>
-	void ObjectLibrary<Type>::Register(const std::string& name, std::shared_ptr<Type> object)
+	void ObjectLibrary<Type>::Register(std::string name, std::shared_ptr<Type> object)
 	{
-		m_library.emplace(name, object);
+		m_library.emplace(std::move(name), object);
 	}
 
 	/*!
@@ -69,7 +69,7 @@ namespace Nz
 	* \param name Name of the object
 	*/
 	template<typename Type>
-	std::shared_ptr<Type> ObjectLibrary<Type>::Query(const std::string& name)
+	std::shared_ptr<Type> ObjectLibrary<Type>::Query(std::string_view name)
 	{
 		auto it = m_library.find(name);
 		if (it != m_library.end())
@@ -84,7 +84,7 @@ namespace Nz
 	* \param name Name of the object
 	*/
 	template<typename Type>
-	void ObjectLibrary<Type>::Unregister(const std::string& name)
+	void ObjectLibrary<Type>::Unregister(std::string_view name)
 	{
 		m_library.erase(name);
 	}

--- a/include/Nazara/Core/ParameterList.hpp
+++ b/include/Nazara/Core/ParameterList.hpp
@@ -11,6 +11,7 @@
 #include <Nazara/Core/Color.hpp>
 #include <NazaraUtils/MovablePtr.hpp>
 #include <NazaraUtils/Result.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <atomic>
 #include <string>
 #include <unordered_map>
@@ -33,19 +34,19 @@ namespace Nz
 			inline void ForEach(const std::function<bool(const ParameterList& list, const std::string& name)>& callback);
 			inline void ForEach(const std::function<void(const ParameterList& list, const std::string& name)>& callback) const;
 
-			Result<bool, Error> GetBooleanParameter(const std::string& name, bool strict = true) const;
-			Result<Color, Error> GetColorParameter(const std::string& name, bool strict = true) const;
-			Result<double, Error> GetDoubleParameter(const std::string& name, bool strict = true) const;
-			Result<long long, Error> GetIntegerParameter(const std::string& name, bool strict = true) const;
-			Result<ParameterType, Error> GetParameterType(const std::string& name) const;
-			Result<void*, Error> GetPointerParameter(const std::string& name, bool strict = true) const;
-			Result<std::string, Error> GetStringParameter(const std::string& name, bool strict = true) const;
-			Result<std::string_view, Error> GetStringViewParameter(const std::string& name, bool strict = true) const;
-			Result<void*, Error> GetUserdataParameter(const std::string& name, bool strict = true) const;
+			Result<bool, Error> GetBooleanParameter(std::string_view name, bool strict = true) const;
+			Result<Color, Error> GetColorParameter(std::string_view name, bool strict = true) const;
+			Result<double, Error> GetDoubleParameter(std::string_view name, bool strict = true) const;
+			Result<long long, Error> GetIntegerParameter(std::string_view name, bool strict = true) const;
+			Result<ParameterType, Error> GetParameterType(std::string_view name) const;
+			Result<void*, Error> GetPointerParameter(std::string_view name, bool strict = true) const;
+			Result<std::string, Error> GetStringParameter(std::string_view name, bool strict = true) const;
+			Result<std::string_view, Error> GetStringViewParameter(std::string_view name, bool strict = true) const;
+			Result<void*, Error> GetUserdataParameter(std::string_view name, bool strict = true) const;
 
-			bool HasParameter(const std::string& name) const;
+			bool HasParameter(std::string_view name) const;
 
-			void RemoveParameter(const std::string& name);
+			void RemoveParameter(std::string_view name);
 
 			void SetParameter(std::string name);
 			void SetParameter(std::string name, const Color& value);
@@ -111,7 +112,7 @@ namespace Nz
 			Parameter& CreateValue(std::string&& name);
 			void DestroyValue(Parameter& parameter);
 
-			using ParameterMap = std::unordered_map<std::string, Parameter>;
+			using ParameterMap = std::unordered_map<std::string, Parameter, StringHash<>, std::equal_to<>>;
 			ParameterMap m_parameters;
 	};
 

--- a/include/Nazara/Core/ResourceSaver.hpp
+++ b/include/Nazara/Core/ResourceSaver.hpp
@@ -31,7 +31,7 @@ namespace Nz
 			struct Entry;
 			using FormatSupport = std::function<bool(std::string_view format)>;
 			using FileSaver = std::function<bool(const Type& resource, const std::filesystem::path& filePath, const Parameters& parameters)>;
-			using StreamSaver = std::function<bool(const Type& resource, const std::string& format, Stream& stream, const Parameters& parameters)>;
+			using StreamSaver = std::function<bool(const Type& resource, std::string_view format, Stream& stream, const Parameters& parameters)>;
 
 			ResourceSaver() = default;
 			ResourceSaver(const ResourceSaver&) = delete;
@@ -43,7 +43,7 @@ namespace Nz
 			bool IsExtensionSupported(std::string_view extension) const;
 
 			bool SaveToFile(const Type& resource, const std::filesystem::path& filePath, const Parameters& parameters = Parameters()) const;
-			bool SaveToStream(const Type& resource, Stream& stream, const std::string& format, const Parameters& parameters = Parameters()) const;
+			bool SaveToStream(const Type& resource, Stream& stream, std::string_view format, const Parameters& parameters = Parameters()) const;
 
 			const Entry* RegisterSaver(Entry saver);
 			void UnregisterSaver(const Entry* saver);

--- a/include/Nazara/Core/ResourceSaver.inl
+++ b/include/Nazara/Core/ResourceSaver.inl
@@ -124,7 +124,7 @@ namespace Nz
 	* \see SaveToFile
 	*/
 	template<typename Type, typename Parameters>
-	bool ResourceSaver<Type, Parameters>::SaveToStream(const Type& resource, Stream& stream, const std::string& format, const Parameters& parameters) const
+	bool ResourceSaver<Type, Parameters>::SaveToStream(const Type& resource, Stream& stream, std::string_view format, const Parameters& parameters) const
 	{
 		NazaraAssert(stream.IsWritable(), "Stream is not writable");
 		NazaraAssert(parameters.IsValid(), "Invalid parameters");

--- a/include/Nazara/Graphics/FramePipelinePassRegistry.hpp
+++ b/include/Nazara/Graphics/FramePipelinePassRegistry.hpp
@@ -9,6 +9,7 @@
 
 #include <NazaraUtils/Prerequisites.hpp>
 #include <Nazara/Graphics/FramePipelinePass.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <functional>
 #include <list>
 #include <string>
@@ -51,8 +52,7 @@ namespace Nz
 				std::vector<std::string> outputs;
 			};
 
-			std::list<std::string> m_passNames; //< in order to allow std::string_view as a key in C++17 (keep std::string stable as well because of SSO)
-			std::unordered_map<std::string_view, std::size_t> m_passIndex;
+			std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>> m_passIndex;
 			std::vector<Pass> m_passes;
 	};
 }

--- a/include/Nazara/Graphics/FramePipelinePassRegistry.inl
+++ b/include/Nazara/Graphics/FramePipelinePassRegistry.inl
@@ -58,10 +58,8 @@ namespace Nz
 		if (m_passIndex.find(passName) != m_passIndex.end())
 			throw std::runtime_error("pass " + passName + " is already registered");
 
-		m_passNames.push_back(std::move(passName));
-
 		std::size_t passIndex = m_passIndex.size();
-		m_passIndex.emplace(m_passNames.back(), passIndex);
+		m_passIndex.emplace(std::move(passName), passIndex);
 		auto& passData = m_passes.emplace_back();
 		passData.factory = std::move(factory);
 		passData.inputs = std::move(inputs);

--- a/include/Nazara/Graphics/Material.hpp
+++ b/include/Nazara/Graphics/Material.hpp
@@ -17,6 +17,7 @@
 #include <Nazara/Graphics/MaterialSettings.hpp>
 #include <Nazara/Graphics/RenderBufferPool.hpp>
 #include <Nazara/Graphics/ShaderReflection.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <NZSL/Ast/Module.hpp>
 #include <array>
 #include <memory>
@@ -51,8 +52,8 @@ namespace Nz
 
 			std::shared_ptr<MaterialInstance> GetDefaultInstance() const;
 
-			inline std::size_t FindTextureByTag(const std::string& tag) const;
-			inline std::size_t FindUniformBlockByTag(const std::string& tag) const;
+			inline std::size_t FindTextureByTag(std::string_view tag) const;
+			inline std::size_t FindUniformBlockByTag(std::string_view tag) const;
 
 			inline UInt32 GetEngineBindingIndex(EngineShaderBinding shaderBinding) const;
 			inline const std::shared_ptr<RenderPipelineLayout>& GetRenderPipelineLayout() const;
@@ -93,8 +94,8 @@ namespace Nz
 		private:
 			std::shared_ptr<RenderPipelineLayout> m_renderPipelineLayout;
 			std::unordered_map<UInt32, nzsl::Ast::ConstantSingleValue> m_optionValues;
-			std::unordered_map<std::string /*tag*/, std::size_t> m_textureByTag;
-			std::unordered_map<std::string /*tag*/, std::size_t> m_uniformBlockByTag;
+			std::unordered_map<std::string /*tag*/, std::size_t, StringHash<>, std::equal_to<>> m_textureByTag;
+			std::unordered_map<std::string /*tag*/, std::size_t, StringHash<>, std::equal_to<>> m_uniformBlockByTag;
 			std::vector<TextureData> m_textures;
 			std::vector<UniformBlockData> m_uniformBlocks;
 			mutable std::weak_ptr<MaterialInstance> m_defaultInstance;

--- a/include/Nazara/Graphics/Material.inl
+++ b/include/Nazara/Graphics/Material.inl
@@ -6,7 +6,7 @@
 
 namespace Nz
 {
-	inline std::size_t Material::FindTextureByTag(const std::string& tag) const
+	inline std::size_t Material::FindTextureByTag(std::string_view tag) const
 	{
 		auto it = m_textureByTag.find(tag);
 		if (it == m_textureByTag.end())
@@ -15,7 +15,7 @@ namespace Nz
 		return it->second;
 	}
 
-	inline std::size_t Material::FindUniformBlockByTag(const std::string& tag) const
+	inline std::size_t Material::FindUniformBlockByTag(std::string_view tag) const
 	{
 		auto it = m_uniformBlockByTag.find(tag);
 		if (it == m_uniformBlockByTag.end())

--- a/include/Nazara/Graphics/MaterialPassRegistry.hpp
+++ b/include/Nazara/Graphics/MaterialPassRegistry.hpp
@@ -8,6 +8,7 @@
 #define NAZARA_GRAPHICS_MATERIALPASSREGISTRY_HPP
 
 #include <NazaraUtils/Prerequisites.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <list>
 #include <string>
 #include <unordered_map>
@@ -30,8 +31,7 @@ namespace Nz
 			MaterialPassRegistry& operator=(MaterialPassRegistry&&) = default;
 
 		private:
-			std::list<std::string> m_passNames; //< in order to allow std::string_view as a key in C++17 (keep std::string stable as well because of SSO)
-			std::unordered_map<std::string_view, std::size_t> m_passIndex;
+			std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>> m_passIndex;
 	};
 }
 

--- a/include/Nazara/Graphics/MaterialPassRegistry.inl
+++ b/include/Nazara/Graphics/MaterialPassRegistry.inl
@@ -18,13 +18,11 @@ namespace Nz
 
 	inline std::size_t MaterialPassRegistry::RegisterPass(std::string passName)
 	{
-		if (m_passIndex.find(passName) != m_passIndex.end())
+		if (m_passIndex.contains(passName))
 			throw std::runtime_error("pass " + passName + " is already registered");
 
-		m_passNames.push_back(std::move(passName));
-
 		std::size_t passIndex = m_passIndex.size();
-		m_passIndex.emplace(m_passNames.back(), passIndex);
+		m_passIndex.emplace(std::move(passName), passIndex);
 
 		return passIndex;
 	}

--- a/include/Nazara/Graphics/ShaderReflection.hpp
+++ b/include/Nazara/Graphics/ShaderReflection.hpp
@@ -10,6 +10,7 @@
 #include <NazaraUtils/Prerequisites.hpp>
 #include <Nazara/Graphics/Config.hpp>
 #include <Nazara/Renderer/RenderPipelineLayout.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <NZSL/Ast/Module.hpp>
 #include <NZSL/Ast/Option.hpp>
 #include <NZSL/Ast/RecursiveVisitor.hpp>
@@ -31,8 +32,8 @@ namespace Nz
 			~ShaderReflection() = default;
 
 			inline const RenderPipelineLayoutInfo& GetPipelineLayoutInfo() const;
-			inline const ExternalBlockData* GetExternalBlockByTag(const std::string& tag) const;
-			inline const OptionData* GetOptionByName(const std::string& optionName) const;
+			inline const ExternalBlockData* GetExternalBlockByTag(std::string_view tag) const;
+			inline const OptionData* GetOptionByName(std::string_view optionName) const;
 			inline const StructData* GetStructByIndex(std::size_t structIndex) const;
 
 			void Reflect(nzsl::Ast::Module& module);
@@ -74,10 +75,10 @@ namespace Nz
 
 			struct ExternalBlockData
 			{
-				std::unordered_map<std::string /*tag*/, ExternalSampler> samplers;
-				std::unordered_map<std::string /*tag*/, ExternalStorageBlock> storageBlocks;
-				std::unordered_map<std::string /*tag*/, ExternalTexture> textures;
-				std::unordered_map<std::string /*tag*/, ExternalUniformBlock> uniformBlocks;
+				std::unordered_map<std::string /*tag*/, ExternalSampler, StringHash<>, std::equal_to<>> samplers;
+				std::unordered_map<std::string /*tag*/, ExternalStorageBlock, StringHash<>, std::equal_to<>> storageBlocks;
+				std::unordered_map<std::string /*tag*/, ExternalTexture, StringHash<>, std::equal_to<>> textures;
+				std::unordered_map<std::string /*tag*/, ExternalUniformBlock, StringHash<>, std::equal_to<>> uniformBlocks;
 			};
 
 			struct OptionData
@@ -97,7 +98,7 @@ namespace Nz
 			{
 				StructData(nzsl::StructLayout layout) : fieldOffsets(layout) {}
 
-				std::unordered_map<std::string /*tag*/, StructMemberData> members;
+				std::unordered_map<std::string /*tag*/, StructMemberData, StringHash<>, std::equal_to<>> members;
 				nzsl::FieldOffsets fieldOffsets;
 			};
 
@@ -107,8 +108,8 @@ namespace Nz
 			void Visit(nzsl::Ast::DeclareOptionStatement& node) override;
 			void Visit(nzsl::Ast::DeclareStructStatement& node) override;
 
-			std::unordered_map<std::string /*tag*/, ExternalBlockData> m_externalBlocks;
-			std::unordered_map<std::string /*name*/, OptionData> m_options;
+			std::unordered_map<std::string /*tag*/, ExternalBlockData, StringHash<>, std::equal_to<>> m_externalBlocks;
+			std::unordered_map<std::string /*name*/, OptionData, StringHash<>, std::equal_to<>> m_options;
 			std::unordered_map<std::size_t /*structIndex*/, StructData> m_structs;
 			RenderPipelineLayoutInfo m_pipelineLayoutInfo;
 			bool m_isConditional;

--- a/include/Nazara/Graphics/ShaderReflection.inl
+++ b/include/Nazara/Graphics/ShaderReflection.inl
@@ -11,7 +11,7 @@ namespace Nz
 		return m_pipelineLayoutInfo;
 	}
 
-	inline auto ShaderReflection::GetExternalBlockByTag(const std::string& tag) const -> const ExternalBlockData*
+	inline auto ShaderReflection::GetExternalBlockByTag(std::string_view tag) const -> const ExternalBlockData*
 	{
 		auto it = m_externalBlocks.find(tag);
 		if (it == m_externalBlocks.end())
@@ -20,7 +20,7 @@ namespace Nz
 		return &it->second;
 	}
 
-	inline auto ShaderReflection::GetOptionByName(const std::string& optionName) const -> const OptionData*
+	inline auto ShaderReflection::GetOptionByName(std::string_view optionName) const -> const OptionData*
 	{
 		auto it = m_options.find(optionName);
 		if (it == m_options.end())

--- a/include/Nazara/Graphics/UberShader.hpp
+++ b/include/Nazara/Graphics/UberShader.hpp
@@ -12,6 +12,7 @@
 #include <Nazara/Graphics/Config.hpp>
 #include <Nazara/Renderer/RenderPipeline.hpp>
 #include <NazaraUtils/Signal.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <NZSL/ModuleResolver.hpp>
 #include <NZSL/Ast/Module.hpp>
 #include <NZSL/Ast/Option.hpp>
@@ -38,7 +39,7 @@ namespace Nz
 
 			const std::shared_ptr<ShaderModule>& Get(const Config& config);
 
-			inline bool HasOption(const std::string& optionName, Pointer<const Option>* option = nullptr) const;
+			inline bool HasOption(std::string_view optionName, Pointer<const Option>* option = nullptr) const;
 
 			inline void UpdateConfig(Config& config, const std::vector<RenderPipelineInfo::VertexBufferData>& vertexBuffers);
 			inline void UpdateConfigCallback(ConfigCallback callback);
@@ -66,13 +67,13 @@ namespace Nz
 			NazaraSignal(OnShaderUpdated, UberShader* /*uberShader*/);
 
 		private:
-			nzsl::Ast::ModulePtr Validate(const nzsl::Ast::Module& module, std::unordered_map<std::string, Option>* options);
+			nzsl::Ast::ModulePtr Validate(const nzsl::Ast::Module& module, std::unordered_map<std::string, Option, StringHash<>, std::equal_to<>>* options);
 
 			NazaraSlot(nzsl::ModuleResolver, OnModuleUpdated, m_onShaderModuleUpdated);
 
 			std::unordered_map<Config, std::shared_ptr<ShaderModule>, ConfigHasher, ConfigEqual> m_combinations;
-			std::unordered_map<std::string, Option> m_optionIndexByName;
-			std::unordered_set<std::string> m_usedModules;
+			std::unordered_map<std::string, Option, StringHash<>, std::equal_to<>> m_optionIndexByName;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_usedModules;
 			nzsl::Ast::ModulePtr m_shaderModule;
 			ConfigCallback m_configCallback;
 			nzsl::ShaderStageTypeFlags m_shaderStages;

--- a/include/Nazara/Graphics/UberShader.inl
+++ b/include/Nazara/Graphics/UberShader.inl
@@ -11,7 +11,7 @@ namespace Nz
 		return m_shaderStages;
 	}
 
-	inline bool UberShader::HasOption(const std::string& optionName, Pointer<const Option>* option) const
+	inline bool UberShader::HasOption(std::string_view optionName, Pointer<const Option>* option) const
 	{
 		auto it = m_optionIndexByName.find(optionName);
 		if (it == m_optionIndexByName.end())

--- a/include/Nazara/OpenGLRenderer/Wrapper/Context.hpp
+++ b/include/Nazara/OpenGLRenderer/Wrapper/Context.hpp
@@ -17,6 +17,7 @@
 #include <Nazara/Renderer/Enums.hpp>
 #include <Nazara/Renderer/RenderStates.hpp>
 #include <NazaraUtils/EnumArray.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <array>
 #include <string>
 #include <unordered_set>
@@ -163,7 +164,7 @@ namespace Nz::GL
 			inline const OpenGLVaoCache& GetVaoCache() const;
 
 			inline bool IsExtensionSupported(Extension extension) const;
-			inline bool IsExtensionSupported(const std::string& extension) const;
+			inline bool IsExtensionSupported(std::string_view extension) const;
 
 			inline bool HasZeroToOneDepth() const;
 
@@ -281,7 +282,7 @@ namespace Nz::GL
 			EnumArray<Extension, ExtensionStatus> m_extensionStatus;
 			std::array<GLFunction, UnderlyingCast(FunctionIndex::Count)> m_originalFunctionPointer;
 			mutable std::unique_ptr<BlitFramebuffers> m_blitFramebuffers;
-			std::unordered_set<std::string> m_supportedExtensions;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_supportedExtensions;
 			OpenGLVaoCache m_vaoCache;
 			const OpenGLDevice* m_device;
 			mutable State m_state;

--- a/include/Nazara/OpenGLRenderer/Wrapper/Context.inl
+++ b/include/Nazara/OpenGLRenderer/Wrapper/Context.inl
@@ -107,9 +107,9 @@ namespace Nz::GL
 		return GetExtensionStatus(extension) != ExtensionStatus::NotSupported;
 	}
 
-	inline bool Context::IsExtensionSupported(const std::string& extension) const
+	inline bool Context::IsExtensionSupported(std::string_view extension) const
 	{
-		return m_supportedExtensions.find(extension) != m_supportedExtensions.end();
+		return m_supportedExtensions.contains(extension);
 	}
 
 	inline bool Context::HasZeroToOneDepth() const

--- a/include/Nazara/OpenGLRenderer/Wrapper/EGL/EGLContextBase.hpp
+++ b/include/Nazara/OpenGLRenderer/Wrapper/EGL/EGLContextBase.hpp
@@ -12,6 +12,7 @@
 #include <Nazara/OpenGLRenderer/Config.hpp>
 #include <Nazara/OpenGLRenderer/Wrapper/Context.hpp>
 #include <Nazara/Platform/WindowHandle.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <string>
@@ -37,7 +38,7 @@ namespace Nz::GL
 
 			PresentModeFlags GetSupportedPresentModes() const override;
 
-			inline bool HasPlatformExtension(const std::string& str) const;
+			inline bool HasPlatformExtension(std::string_view str) const;
 
 			void SetPresentMode(PresentMode presentMode) override;
 
@@ -72,7 +73,7 @@ namespace Nz::GL
 			};
 			Fallback fallbacks; //< m_ omitted
 
-			std::unordered_set<std::string> m_supportedPlatformExtensions;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_supportedPlatformExtensions;
 			EGLContext m_handle;
 			EGLint m_maxSwapInterval;
 			EGLint m_minSwapInterval;

--- a/include/Nazara/OpenGLRenderer/Wrapper/EGL/EGLContextBase.inl
+++ b/include/Nazara/OpenGLRenderer/Wrapper/EGL/EGLContextBase.inl
@@ -16,9 +16,9 @@ namespace Nz::GL
 	{
 	}
 
-	inline bool EGLContextBase::HasPlatformExtension(const std::string& str) const
+	inline bool EGLContextBase::HasPlatformExtension(std::string_view str) const
 	{
-		return m_supportedPlatformExtensions.find(str) != m_supportedPlatformExtensions.end();
+		return m_supportedPlatformExtensions.contains(str);
 	}
 }
 

--- a/include/Nazara/OpenGLRenderer/Wrapper/WGL/WGLContext.hpp
+++ b/include/Nazara/OpenGLRenderer/Wrapper/WGL/WGLContext.hpp
@@ -14,6 +14,7 @@
 #include <Nazara/OpenGLRenderer/Wrapper/WGL/WGLFunctions.hpp>
 #include <Nazara/OpenGLRenderer/Wrapper/Win32/Win32Helper.hpp>
 #include <Nazara/Platform/WindowHandle.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <string>
 #include <type_traits>
 #include <unordered_set>
@@ -36,7 +37,7 @@ namespace Nz::GL
 
 			PresentModeFlags GetSupportedPresentModes() const override;
 
-			inline bool HasPlatformExtension(const std::string& str) const;
+			inline bool HasPlatformExtension(std::string_view str) const;
 
 			void SetPresentMode(PresentMode presentMode) override;
 
@@ -73,7 +74,7 @@ namespace Nz::GL
 			};
 			Fallback fallbacks; //< m_ omitted
 
-			std::unordered_set<std::string> m_supportedPlatformExtensions;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_supportedPlatformExtensions;
 			const WGLLoader& m_loader;
 			HDC m_deviceContext;
 			HGLRC m_handle;

--- a/include/Nazara/OpenGLRenderer/Wrapper/WGL/WGLContext.inl
+++ b/include/Nazara/OpenGLRenderer/Wrapper/WGL/WGLContext.inl
@@ -13,7 +13,7 @@ namespace Nz::GL
 	{
 	}
 
-	inline bool WGLContext::HasPlatformExtension(const std::string& str) const
+	inline bool WGLContext::HasPlatformExtension(std::string_view str) const
 	{
 		return m_supportedPlatformExtensions.find(str) != m_supportedPlatformExtensions.end();
 	}

--- a/include/Nazara/OpenGLRenderer/Wrapper/Web/WebContext.hpp
+++ b/include/Nazara/OpenGLRenderer/Wrapper/Web/WebContext.hpp
@@ -12,6 +12,7 @@
 #include <Nazara/OpenGLRenderer/Config.hpp>
 #include <Nazara/OpenGLRenderer/Wrapper/Context.hpp>
 #include <Nazara/Platform/WindowHandle.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <emscripten/html5.h>
 #include <string>
 #include <type_traits>
@@ -35,7 +36,7 @@ namespace Nz::GL
 
 			PresentModeFlags GetSupportedPresentModes() const override;
 
-			inline bool HasPlatformExtension(const std::string& str) const;
+			inline bool HasPlatformExtension(std::string_view str) const;
 
 			void SetPresentMode(PresentMode presentMode) override;
 
@@ -66,7 +67,7 @@ namespace Nz::GL
 			};
 			Fallback fallbacks; //< m_ omitted
 
-			std::unordered_set<std::string> m_supportedPlatformExtensions;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_supportedPlatformExtensions;
 			EMSCRIPTEN_WEBGL_CONTEXT_HANDLE m_handle;
 	};
 }

--- a/include/Nazara/OpenGLRenderer/Wrapper/Web/WebContext.inl
+++ b/include/Nazara/OpenGLRenderer/Wrapper/Web/WebContext.inl
@@ -13,9 +13,9 @@ namespace Nz::GL
 	{
 	}
 
-	inline bool WebContext::HasPlatformExtension(const std::string& str) const
+	inline bool WebContext::HasPlatformExtension(std::string_view str) const
 	{
-		return m_supportedPlatformExtensions.find(str) != m_supportedPlatformExtensions.end();
+		return m_supportedPlatformExtensions.contains(str);
 	}
 }
 

--- a/include/Nazara/Utility/Animation.hpp
+++ b/include/Nazara/Utility/Animation.hpp
@@ -64,7 +64,7 @@ namespace Nz
 			Animation(Animation&&) noexcept;
 			~Animation();
 
-			bool AddSequence(const Sequence& sequence);
+			bool AddSequence(Sequence sequence);
 			void AnimateSkeleton(Skeleton* targetSkeleton, std::size_t frameA, std::size_t frameB, float interpolation) const;
 
 			bool CreateSkeletal(std::size_t frameCount, std::size_t jointCount);
@@ -74,23 +74,23 @@ namespace Nz
 
 			std::size_t GetFrameCount() const;
 			std::size_t GetJointCount() const;
-			Sequence* GetSequence(const std::string& sequenceName);
+			Sequence* GetSequence(std::string_view sequenceName);
 			Sequence* GetSequence(std::size_t index);
-			const Sequence* GetSequence(const std::string& sequenceName) const;
+			const Sequence* GetSequence(std::string_view sequenceName) const;
 			const Sequence* GetSequence(std::size_t index) const;
 			std::size_t GetSequenceCount() const;
-			std::size_t GetSequenceIndex(const std::string& sequenceName) const;
+			std::size_t GetSequenceIndex(std::string_view sequenceName) const;
 			SequenceJoint* GetSequenceJoints(std::size_t frameIndex = 0);
 			const SequenceJoint* GetSequenceJoints(std::size_t frameIndex = 0) const;
 			AnimationType GetType() const;
 
-			bool HasSequence(const std::string& sequenceName) const;
+			bool HasSequence(std::string_view sequenceName) const;
 			bool HasSequence(std::size_t index = 0) const;
 
 			bool IsLoopPointInterpolationEnabled() const;
 			bool IsValid() const;
 
-			void RemoveSequence(const std::string& sequenceName);
+			void RemoveSequence(std::string_view sequenceName);
 			void RemoveSequence(std::size_t index);
 
 			Animation& operator=(const Animation&) = delete;

--- a/include/Nazara/Utility/Animation.inl
+++ b/include/Nazara/Utility/Animation.inl
@@ -2,7 +2,6 @@
 // This file is part of the "Nazara Engine - Utility module"
 // For conditions of distribution and use, see copyright notice in Config.hpp
 
-#include <memory>
 #include <Nazara/Utility/Debug.hpp>
 
 namespace Nz

--- a/include/Nazara/Utility/Formats/MD5AnimParser.hpp
+++ b/include/Nazara/Utility/Formats/MD5AnimParser.hpp
@@ -57,12 +57,12 @@ namespace Nz
 
 		private:
 			bool Advance(bool required = true);
-			void Error(const std::string& message);
+			void Error(std::string_view message);
 			bool ParseBaseframe();
 			bool ParseBounds();
 			bool ParseFrame();
 			bool ParseHierarchy();
-			void Warning(const std::string& message);
+			void Warning(std::string_view message);
 			void UnrecognizedLine(bool error = false);
 
 			std::vector<float> m_animatedComponents;

--- a/include/Nazara/Utility/Formats/MD5MeshParser.hpp
+++ b/include/Nazara/Utility/Formats/MD5MeshParser.hpp
@@ -66,10 +66,10 @@ namespace Nz
 
 		private:
 			bool Advance(bool required = true);
-			void Error(const std::string& message);
+			void Error(std::string_view message);
 			bool ParseJoints();
 			bool ParseMesh();
-			void Warning(const std::string& message);
+			void Warning(std::string_view message);
 			void UnrecognizedLine(bool error = false);
 
 			std::vector<Joint> m_joints;

--- a/include/Nazara/Utility/Formats/MTLParser.hpp
+++ b/include/Nazara/Utility/Formats/MTLParser.hpp
@@ -10,6 +10,7 @@
 #include <NazaraUtils/Prerequisites.hpp>
 #include <Nazara/Core/Color.hpp>
 #include <Nazara/Utility/Config.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <unordered_map>
 
 namespace Nz
@@ -22,12 +23,12 @@ namespace Nz
 			MTLParser() = default;
 			~MTLParser() = default;
 
-			inline Material* AddMaterial(const std::string& matName);
+			inline Material* AddMaterial(std::string matName);
 
 			inline void Clear();
 
-			inline const Material* GetMaterial(const std::string& materialName) const;
-			inline const std::unordered_map<std::string, Material>& GetMaterials() const;
+			inline const Material* GetMaterial(std::string_view materialName) const;
+			inline const std::unordered_map<std::string, Material, StringHash<>, std::equal_to<>>& GetMaterials() const;
 
 			bool Parse(Stream& stream);
 
@@ -60,12 +61,12 @@ namespace Nz
 			template<typename T> void Emit(const T& text) const;
 			inline void EmitLine() const;
 			template<typename T> void EmitLine(const T& line) const;
-			inline void Error(const std::string& message);
+			inline void Error(std::string_view message);
 			inline void Flush() const;
-			inline void Warning(const std::string& message);
+			inline void Warning(std::string_view message);
 			inline void UnrecognizedLine(bool error = false);
 
-			std::unordered_map<std::string, Material> m_materials;
+			std::unordered_map<std::string, Material, StringHash<>, std::equal_to<>> m_materials;
 			mutable Stream* m_currentStream;
 			std::string m_currentLine;
 			mutable std::ostringstream m_outputStream;

--- a/include/Nazara/Utility/Formats/MTLParser.inl
+++ b/include/Nazara/Utility/Formats/MTLParser.inl
@@ -7,9 +7,9 @@
 
 namespace Nz
 {
-	inline MTLParser::Material* MTLParser::AddMaterial(const std::string& matName)
+	inline MTLParser::Material* MTLParser::AddMaterial(std::string matName)
 	{
-		return &m_materials[matName];
+		return &m_materials[std::move(matName)];
 	}
 
 	inline void MTLParser::Clear()
@@ -17,7 +17,7 @@ namespace Nz
 		m_materials.clear();
 	}
 
-	inline const MTLParser::Material* MTLParser::GetMaterial(const std::string& materialName) const
+	inline const MTLParser::Material* MTLParser::GetMaterial(std::string_view materialName) const
 	{
 		auto it = m_materials.find(materialName);
 		if (it != m_materials.end())
@@ -26,7 +26,7 @@ namespace Nz
 			return nullptr;
 	}
 
-	inline const std::unordered_map<std::string, MTLParser::Material>& MTLParser::GetMaterials() const
+	inline auto MTLParser::GetMaterials() const -> const std::unordered_map<std::string, Material, StringHash<>, std::equal_to<>>&
 	{
 		return m_materials;
 	}
@@ -51,7 +51,7 @@ namespace Nz
 		Emit('\n');
 	}
 
-	inline void MTLParser::Error(const std::string& message)
+	inline void MTLParser::Error(std::string_view message)
 	{
 		NazaraErrorFmt("{0} at line #{1}", message, m_lineCount);
 	}
@@ -62,7 +62,7 @@ namespace Nz
 		m_outputStream.str({});
 	}
 
-	inline void MTLParser::Warning(const std::string& message)
+	inline void MTLParser::Warning(std::string_view message)
 	{
 		NazaraWarningFmt("{0} at line #{1}", message, m_lineCount);
 	}

--- a/include/Nazara/Utility/Formats/OBJParser.hpp
+++ b/include/Nazara/Utility/Formats/OBJParser.hpp
@@ -81,9 +81,9 @@ namespace Nz
 			template<typename T> void Emit(const T& text) const;
 			inline void EmitLine() const;
 			template<typename T> void EmitLine(const T& line) const;
-			inline void Error(const std::string& message);
+			inline void Error(std::string_view message);
 			inline void Flush() const;
-			inline void Warning(const std::string& message);
+			inline void Warning(std::string_view message);
 			inline bool UnrecognizedLine(bool error = false);
 
 			std::vector<Mesh> m_meshes;

--- a/include/Nazara/Utility/Formats/OBJParser.inl
+++ b/include/Nazara/Utility/Formats/OBJParser.inl
@@ -151,7 +151,7 @@ namespace Nz
 		Emit('\n');
 	}
 
-	inline void OBJParser::Error(const std::string& message)
+	inline void OBJParser::Error(std::string_view message)
 	{
 		NazaraErrorFmt("{0} on line #{1}", message, m_lineCount);
 	}
@@ -162,7 +162,7 @@ namespace Nz
 		m_outputStream.str({});
 	}
 
-	inline void OBJParser::Warning(const std::string& message)
+	inline void OBJParser::Warning(std::string_view message)
 	{
 		NazaraWarningFmt("{0} on line #{1}", message, m_lineCount);
 	}

--- a/include/Nazara/Utility/Image.hpp
+++ b/include/Nazara/Utility/Image.hpp
@@ -97,7 +97,7 @@ namespace Nz
 
 			// Save
 			bool SaveToFile(const std::filesystem::path& filePath, const ImageParams& params = ImageParams());
-			bool SaveToStream(Stream& stream, const std::string& format, const ImageParams& params = ImageParams());
+			bool SaveToStream(Stream& stream, std::string_view format, const ImageParams& params = ImageParams());
 
 			//TODO: SaveArray, SaveCubemap, SaveFace
 

--- a/include/Nazara/Utility/Mesh.hpp
+++ b/include/Nazara/Utility/Mesh.hpp
@@ -101,7 +101,7 @@ namespace Nz
 			~Mesh() = default;
 
 			void AddSubMesh(std::shared_ptr<SubMesh> subMesh);
-			void AddSubMesh(const std::string& identifier, std::shared_ptr<SubMesh> subMesh);
+			void AddSubMesh(std::string identifier, std::shared_ptr<SubMesh> subMesh);
 
 			std::shared_ptr<SubMesh> BuildSubMesh(const Primitive& primitive, const MeshParams& params = MeshParams());
 			void BuildSubMeshes(const PrimitiveList& primitiveList, const MeshParams& params = MeshParams());
@@ -123,14 +123,14 @@ namespace Nz
 			std::size_t GetMaterialCount() const;
 			Skeleton* GetSkeleton();
 			const Skeleton* GetSkeleton() const;
-			const std::shared_ptr<SubMesh>& GetSubMesh(const std::string& identifier) const;
+			const std::shared_ptr<SubMesh>& GetSubMesh(std::string_view identifier) const;
 			const std::shared_ptr<SubMesh>& GetSubMesh(std::size_t index) const;
 			std::size_t GetSubMeshCount() const;
-			std::size_t GetSubMeshIndex(const std::string& identifier) const;
+			std::size_t GetSubMeshIndex(std::string_view identifier) const;
 			UInt32 GetTriangleCount() const;
 			UInt32 GetVertexCount() const;
 
-			bool HasSubMesh(const std::string& identifier) const;
+			bool HasSubMesh(std::string_view identifier) const;
 			bool HasSubMesh(std::size_t index = 0) const;
 
 			void InvalidateAABB() const;
@@ -140,11 +140,11 @@ namespace Nz
 
 			void Recenter();
 
-			void RemoveSubMesh(const std::string& identifier);
+			void RemoveSubMesh(std::string_view identifier);
 			void RemoveSubMesh(std::size_t index);
 
 			bool SaveToFile(const std::filesystem::path& filePath, const MeshParams& params = MeshParams());
-			bool SaveToStream(Stream& stream, const std::string& format, const MeshParams& params = MeshParams());
+			bool SaveToStream(Stream& stream, std::string_view format, const MeshParams& params = MeshParams());
 
 			void SetAnimation(const std::filesystem::path& animationPath);
 			void SetMaterialCount(std::size_t matCount);
@@ -175,7 +175,7 @@ namespace Nz
 			};
 
 			std::size_t m_jointCount; // Only used by skeletal meshes
-			std::unordered_map<std::string, std::size_t> m_subMeshMap;
+			std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>> m_subMeshMap;
 			std::vector<ParameterList> m_materialData;
 			std::vector<SubMeshData> m_subMeshes;
 			AnimationType m_animationType;

--- a/include/Nazara/Utility/Skeleton.hpp
+++ b/include/Nazara/Utility/Skeleton.hpp
@@ -37,14 +37,14 @@ namespace Nz
 			void Destroy();
 
 			const Boxf& GetAABB() const;
-			Joint* GetJoint(const std::string& jointName);
+			Joint* GetJoint(std::string_view jointName);
 			Joint* GetJoint(std::size_t index);
-			const Joint* GetJoint(const std::string& jointName) const;
+			const Joint* GetJoint(std::string_view jointName) const;
 			const Joint* GetJoint(std::size_t index) const;
 			Joint* GetJoints();
 			const Joint* GetJoints() const;
 			std::size_t GetJointCount() const;
-			std::size_t GetJointIndex(const std::string& jointName) const;
+			std::size_t GetJointIndex(std::string_view jointName) const;
 			Joint* GetRootJoint();
 			const Joint* GetRootJoint() const;
 

--- a/include/Nazara/VulkanRenderer/Wrapper/Device.hpp
+++ b/include/Nazara/VulkanRenderer/Wrapper/Device.hpp
@@ -14,6 +14,7 @@
 #include <Nazara/VulkanRenderer/Wrapper/Loader.hpp>
 #include <Nazara/VulkanRenderer/Wrapper/PhysicalDevice.hpp>
 #include <NazaraUtils/EnumArray.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <vulkan/vulkan_core.h>
 #include <array>
 #include <memory>
@@ -62,8 +63,8 @@ namespace Nz
 				inline PFN_vkVoidFunction GetProcAddr(const char* name, bool allowInstanceFallback);
 				QueueHandle GetQueue(UInt32 queueFamilyIndex, UInt32 queueIndex);
 
-				inline bool IsExtensionLoaded(const std::string& extensionName);
-				inline bool IsLayerLoaded(const std::string& layerName);
+				inline bool IsExtensionLoaded(std::string_view extensionName);
+				inline bool IsLayerLoaded(std::string_view layerName);
 
 				inline void SetDebugName(VkObjectType objectType, UInt64 objectHandle, const char* name);
 				inline void SetDebugName(VkObjectType objectType, UInt64 objectHandle, std::string_view name);
@@ -107,8 +108,8 @@ namespace Nz
 				struct InternalData;
 
 				std::unique_ptr<InternalData> m_internalData;
-				std::unordered_set<std::string> m_loadedExtensions;
-				std::unordered_set<std::string> m_loadedLayers;
+				std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_loadedExtensions;
+				std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_loadedLayers;
 				std::vector<QueueFamilyInfo> m_enabledQueuesInfos;
 				std::vector<const QueueList*> m_queuesByFamily;
 				Instance& m_instance;

--- a/include/Nazara/VulkanRenderer/Wrapper/Device.inl
+++ b/include/Nazara/VulkanRenderer/Wrapper/Device.inl
@@ -77,12 +77,12 @@ namespace Nz::Vk
 		return func;
 	}
 
-	inline bool Device::IsExtensionLoaded(const std::string& extensionName)
+	inline bool Device::IsExtensionLoaded(std::string_view extensionName)
 	{
 		return m_loadedExtensions.count(extensionName) > 0;
 	}
 
-	inline bool Device::IsLayerLoaded(const std::string& layerName)
+	inline bool Device::IsLayerLoaded(std::string_view layerName)
 	{
 		return m_loadedLayers.count(layerName) > 0;
 	}

--- a/include/Nazara/VulkanRenderer/Wrapper/Instance.hpp
+++ b/include/Nazara/VulkanRenderer/Wrapper/Instance.hpp
@@ -11,6 +11,7 @@
 #include <Nazara/Renderer/Enums.hpp>
 #include <Nazara/VulkanRenderer/Config.hpp>
 #include <Nazara/VulkanRenderer/Wrapper/Loader.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <vulkan/vulkan_core.h>
 #include <string>
 #include <unordered_set>
@@ -88,8 +89,8 @@ namespace Nz::Vk
 
 			void InstallDebugMessageCallback(RenderAPIValidationLevel validationLevel);
 
-			inline bool IsExtensionLoaded(const std::string& extensionName) const;
-			inline bool IsLayerLoaded(const std::string& layerName) const;
+			inline bool IsExtensionLoaded(std::string_view extensionName) const;
+			inline bool IsLayerLoaded(std::string_view layerName) const;
 			inline bool IsValid() const;
 
 			Instance& operator=(const Instance&) = delete;
@@ -110,8 +111,8 @@ namespace Nz::Vk
 			struct InternalData;
 
 			std::unique_ptr<InternalData> m_internalData;
-			std::unordered_set<std::string> m_loadedExtensions;
-			std::unordered_set<std::string> m_loadedLayers;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_loadedExtensions;
+			std::unordered_set<std::string, StringHash<>, std::equal_to<>> m_loadedLayers;
 			VkAllocationCallbacks m_allocator;
 			VkInstance m_instance;
 			mutable VkResult m_lastErrorCode;

--- a/include/Nazara/VulkanRenderer/Wrapper/Instance.inl
+++ b/include/Nazara/VulkanRenderer/Wrapper/Instance.inl
@@ -79,12 +79,12 @@ namespace Nz::Vk
 		return m_validationLevel;
 	}
 
-	inline bool Instance::IsExtensionLoaded(const std::string& extensionName) const
+	inline bool Instance::IsExtensionLoaded(std::string_view extensionName) const
 	{
 		return m_loadedExtensions.count(extensionName) > 0;
 	}
 
-	inline bool Instance::IsLayerLoaded(const std::string& layerName) const
+	inline bool Instance::IsLayerLoaded(std::string_view layerName) const
 	{
 		return m_loadedLayers.count(layerName) > 0;
 	}

--- a/include/Nazara/VulkanRenderer/Wrapper/PhysicalDevice.hpp
+++ b/include/Nazara/VulkanRenderer/Wrapper/PhysicalDevice.hpp
@@ -7,6 +7,7 @@
 #ifndef NAZARA_VULKANRENDERER_WRAPPER_PHYSICALDEVICE_HPP
 #define NAZARA_VULKANRENDERER_WRAPPER_PHYSICALDEVICE_HPP
 
+#include <NazaraUtils/StringHash.hpp>
 #include <vulkan/vulkan_core.h>
 #include <string>
 #include <unordered_set>
@@ -20,7 +21,7 @@ namespace Nz::Vk
 		VkPhysicalDeviceFeatures features;
 		VkPhysicalDeviceMemoryProperties memoryProperties;
 		VkPhysicalDeviceProperties properties;
-		std::unordered_set<std::string> extensions;
+		std::unordered_set<std::string, StringHash<>, std::equal_to<>> extensions;
 		std::vector<VkQueueFamilyProperties> queueFamilies;
 	};
 }

--- a/plugins/Assimp/Plugin.cpp
+++ b/plugins/Assimp/Plugin.cpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #include <CustomStream.hpp>
 #include <NazaraUtils/Bitset.hpp>
 #include <NazaraUtils/CallOnExit.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <Nazara/Core/Error.hpp>
 #include <Nazara/Utility/Animation.hpp>
 #include <Nazara/Utility/Mesh.hpp>
@@ -84,7 +85,7 @@ struct SceneInfo
 	{
 		const aiMesh* mesh;
 		std::size_t nodeIndex;
-		std::unordered_map<std::string, unsigned int> bones;
+		std::unordered_map<std::string, unsigned int, Nz::StringHash<>, std::equal_to<>> bones;
 	};
 
 	struct StaticMesh
@@ -95,7 +96,7 @@ struct SceneInfo
 
 	std::size_t skeletonRootIndex;
 	std::unordered_map<const aiBone*, unsigned int> assimpBoneToJointIndex;
-	std::unordered_multimap<std::string, std::size_t> nodeByName;
+	std::unordered_multimap<std::string, std::size_t, Nz::StringHash<>, std::equal_to<>> nodeByName;
 	std::vector<Node> nodes;
 	std::vector<SkeletalMesh> skeletalMeshes;
 	std::vector<StaticMesh> staticMeshes;

--- a/src/Nazara/Core/ParameterList.cpp
+++ b/src/Nazara/Core/ParameterList.cpp
@@ -55,7 +55,7 @@ namespace Nz
 	          Integer: 0 is interpreted as false, any other value is interpreted as true
 	          std::string:  Conversion obeys the rule as described by std::string::ToBool
 	*/
-	auto ParameterList::GetBooleanParameter(const std::string& name, bool strict) const -> Result<bool, Error>
+	auto ParameterList::GetBooleanParameter(std::string_view name, bool strict) const -> Result<bool, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -105,7 +105,7 @@ namespace Nz
 	*
 	* \remark If the parameter is not a color, the function fails
 	*/
-	auto ParameterList::GetColorParameter(const std::string& name, bool /*strict*/) const -> Result<Color, Error>
+	auto ParameterList::GetColorParameter(std::string_view name, bool /*strict*/) const -> Result<Color, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -140,7 +140,7 @@ namespace Nz
 	          Integer: The integer value is converted to its double representation
 	          std::string:  Conversion obeys the rule as described by std::string::ToDouble
 	*/
-	auto ParameterList::GetDoubleParameter(const std::string& name, bool strict) const -> Result<double, Error>
+	auto ParameterList::GetDoubleParameter(std::string_view name, bool strict) const -> Result<double, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -199,7 +199,7 @@ namespace Nz
 	          Double:  The floating-point value is truncated and converted to a integer
 	          std::string:  Conversion obeys the rule as described by std::string::ToInteger
 	*/
-	auto ParameterList::GetIntegerParameter(const std::string& name, bool strict) const -> Result<long long, Error>
+	auto ParameterList::GetIntegerParameter(std::string_view name, bool strict) const -> Result<long long, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -259,7 +259,7 @@ namespace Nz
 	*
 	* \remark type must be a valid pointer to a ParameterType variable
 	*/
-	auto ParameterList::GetParameterType(const std::string& name) const -> Result<ParameterType, Error>
+	auto ParameterList::GetParameterType(std::string_view name) const -> Result<ParameterType, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -278,7 +278,7 @@ namespace Nz
 	* \remark If the parameter is not a pointer, a conversion may be performed if strict parameter is set to false, compatibles types are:
 	          Userdata: The pointer part of the userdata is returned
 	*/
-	auto ParameterList::GetPointerParameter(const std::string& name, bool strict) const -> Result<void*, Error>
+	auto ParameterList::GetPointerParameter(std::string_view name, bool strict) const -> Result<void*, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -323,7 +323,7 @@ namespace Nz
 	          Pointer:  Conversion obeys the rules of PointerToString
 	          Userdata: Conversion obeys the rules of PointerToString
 	*/
-	auto ParameterList::GetStringParameter(const std::string& name, bool strict) const -> Result<std::string, Error>
+	auto ParameterList::GetStringParameter(std::string_view name, bool strict) const -> Result<std::string, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -391,7 +391,7 @@ namespace Nz
 			  Boolean:  A string view containing true or false
 			  None:     An empty string view is returned
 	*/
-	auto ParameterList::GetStringViewParameter(const std::string& name, bool strict) const -> Result<std::string_view, Error>
+	auto ParameterList::GetStringViewParameter(std::string_view name, bool strict) const -> Result<std::string_view, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -436,7 +436,7 @@ namespace Nz
 	*
 	* \see GetPointerParameter
 	*/
-	auto ParameterList::GetUserdataParameter(const std::string& name, bool /*strict*/) const -> Result<void*, Error>
+	auto ParameterList::GetUserdataParameter(std::string_view name, bool /*strict*/) const -> Result<void*, Error>
 	{
 		auto it = m_parameters.find(name);
 		if (it == m_parameters.end())
@@ -456,7 +456,7 @@ namespace Nz
 	*
 	* \param name Name of the parameter
 	*/
-	bool ParameterList::HasParameter(const std::string& name) const
+	bool ParameterList::HasParameter(std::string_view name) const
 	{
 		return m_parameters.find(name) != m_parameters.end();
 	}
@@ -469,7 +469,7 @@ namespace Nz
 	*
 	* \param name Name of the parameter
 	*/
-	void ParameterList::RemoveParameter(const std::string& name)
+	void ParameterList::RemoveParameter(std::string_view name)
 	{
 		auto it = m_parameters.find(name);
 		if (it != m_parameters.end())

--- a/src/Nazara/Graphics/Formats/PipelinePassListLoader.cpp
+++ b/src/Nazara/Graphics/Formats/PipelinePassListLoader.cpp
@@ -5,6 +5,7 @@
 #include <Nazara/Graphics/Formats/PipelinePassListLoader.hpp>
 #include <Nazara/Core/ParameterFile.hpp>
 #include <Nazara/Graphics/Graphics.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <optional>
 #include <Nazara/Graphics/Debug.hpp>
 
@@ -183,7 +184,7 @@ namespace Nz::Loaders
 						throw ResourceLoadingError::DecodingError;
 					}
 
-					std::size_t passId = m_current->passList->AddPass(passName, implIndex, std::move(implConfig));
+					std::size_t passId = m_current->passList->AddPass(std::move(passName), implIndex, std::move(implConfig));
 
 					for (auto&& [inputName, attachmentName] : inputs)
 					{
@@ -262,7 +263,7 @@ namespace Nz::Loaders
 				struct CurrentPassList
 				{
 					std::shared_ptr<PipelinePassList> passList;
-					std::unordered_map<std::string /*attachmentName*/, std::size_t /*attachmentId*/> attachmentsByName;
+					std::unordered_map<std::string /*attachmentName*/, std::size_t /*attachmentId*/, StringHash<>, std::equal_to<>> attachmentsByName;
 				};
 
 				std::optional<CurrentPassList> m_current;

--- a/src/Nazara/Graphics/ShaderReflection.cpp
+++ b/src/Nazara/Graphics/ShaderReflection.cpp
@@ -35,7 +35,7 @@ namespace Nz
 		ExternalBlockData* externalBlock = nullptr;
 		if (!node.tag.empty())
 		{
-			if (m_externalBlocks.find(node.tag) != m_externalBlocks.end())
+			if (m_externalBlocks.contains(node.tag))
 				throw std::runtime_error("duplicate tag " + node.tag);
 
 			externalBlock = &m_externalBlocks[node.tag];
@@ -90,7 +90,7 @@ namespace Nz
 				{
 					case ShaderBindingType::Sampler:
 					{
-						if (externalBlock->samplers.find(externalVar.tag) != externalBlock->samplers.end())
+						if (externalBlock->samplers.contains(externalVar.tag))
 							throw std::runtime_error("duplicate sampler tag " + externalVar.tag + " in external block " + node.tag);
 
 						const auto& samplerType = std::get<nzsl::Ast::SamplerType>(*varType);
@@ -105,7 +105,7 @@ namespace Nz
 
 					case ShaderBindingType::StorageBuffer:
 					{
-						if (externalBlock->storageBlocks.find(externalVar.tag) != externalBlock->storageBlocks.end())
+						if (externalBlock->storageBlocks.contains(externalVar.tag))
 							throw std::runtime_error("duplicate storage buffer tag " + externalVar.tag + " in external block " + node.tag);
 
 						ExternalStorageBlock& storageBuffer = externalBlock->storageBlocks[externalVar.tag];
@@ -117,7 +117,7 @@ namespace Nz
 
 					case ShaderBindingType::Texture:
 					{
-						if (externalBlock->textures.find(externalVar.tag) != externalBlock->textures.end())
+						if (externalBlock->textures.contains(externalVar.tag))
 							throw std::runtime_error("duplicate textures tag " + externalVar.tag + " in external block " + node.tag);
 
 						const auto& textureType = std::get<nzsl::Ast::TextureType>(*varType);
@@ -134,7 +134,7 @@ namespace Nz
 
 					case ShaderBindingType::UniformBuffer:
 					{
-						if (externalBlock->uniformBlocks.find(externalVar.tag) != externalBlock->uniformBlocks.end())
+						if (externalBlock->uniformBlocks.contains(externalVar.tag))
 							throw std::runtime_error("duplicate storage buffer tag " + externalVar.tag + " in external block " + node.tag);
 
 						ExternalUniformBlock& uniformBuffer = externalBlock->uniformBlocks[externalVar.tag];

--- a/src/Nazara/Graphics/UberShader.cpp
+++ b/src/Nazara/Graphics/UberShader.cpp
@@ -38,7 +38,7 @@ namespace Nz
 
 		m_onShaderModuleUpdated.Connect(moduleResolver.OnModuleUpdated, [this, name = std::move(moduleName)](nzsl::ModuleResolver* resolver, const std::string& updatedModuleName)
 		{
-			if (m_usedModules.find(updatedModuleName) == m_usedModules.end())
+			if (!m_usedModules.contains(updatedModuleName))
 				return;
 
 			nzsl::Ast::ModulePtr newShaderModule = resolver->Resolve(name);
@@ -108,7 +108,7 @@ namespace Nz
 		return it->second;
 	}
 
-	nzsl::Ast::ModulePtr UberShader::Validate(const nzsl::Ast::Module& module, std::unordered_map<std::string, Option>* options)
+	nzsl::Ast::ModulePtr UberShader::Validate(const nzsl::Ast::Module& module, std::unordered_map<std::string, Option, StringHash<>, std::equal_to<>>* options)
 	{
 		NazaraAssert(m_shaderStages != 0, "there must be at least one shader stage");
 		assert(options);
@@ -132,7 +132,7 @@ namespace Nz
 			supportedStageType |= stageType;
 		};
 
-		std::unordered_map<std::string, Option> optionByName;
+		std::unordered_map<std::string, Option, StringHash<>, std::equal_to<>> optionByName;
 		callbacks.onOptionDeclaration = [&](const nzsl::Ast::DeclareOptionStatement& option)
 		{
 			//TODO: Check optionType

--- a/src/Nazara/Utility/Animation.cpp
+++ b/src/Nazara/Utility/Animation.cpp
@@ -17,7 +17,7 @@ namespace Nz
 {
 	struct AnimationImpl
 	{
-		std::unordered_map<std::string, std::size_t> sequenceMap;
+		std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>> sequenceMap;
 		std::vector<Sequence> sequences;
 		std::vector<SequenceJoint> sequenceJoints; // Uniquement pour les animations squelettiques
 		AnimationType type;
@@ -47,7 +47,7 @@ namespace Nz
 	Animation::Animation(Animation&&) noexcept = default;
 	Animation::~Animation() = default;
 
-	bool Animation::AddSequence(const Sequence& sequence)
+	bool Animation::AddSequence(Sequence sequence)
 	{
 		NazaraAssert(m_impl, "Animation not created");
 		NazaraAssert(sequence.frameCount > 0, "Sequence frame count must be over zero");
@@ -76,7 +76,7 @@ namespace Nz
 			m_impl->sequenceMap[sequence.name] = static_cast<std::size_t>(m_impl->sequences.size());
 		}
 
-		m_impl->sequences.push_back(sequence);
+		m_impl->sequences.emplace_back(std::move(sequence));
 
 		return true;
 	}
@@ -145,7 +145,7 @@ namespace Nz
 		return m_impl->jointCount;
 	}
 
-	Sequence* Animation::GetSequence(const std::string& sequenceName)
+	Sequence* Animation::GetSequence(std::string_view sequenceName)
 	{
 		NazaraAssert(m_impl, "Animation not created");
 
@@ -167,7 +167,7 @@ namespace Nz
 		return &m_impl->sequences[index];
 	}
 
-	const Sequence* Animation::GetSequence(const std::string& sequenceName) const
+	const Sequence* Animation::GetSequence(std::string_view sequenceName) const
 	{
 		NazaraAssert(m_impl, "Animation not created");
 
@@ -196,7 +196,7 @@ namespace Nz
 		return static_cast<std::size_t>(m_impl->sequences.size());
 	}
 
-	std::size_t Animation::GetSequenceIndex(const std::string& sequenceName) const
+	std::size_t Animation::GetSequenceIndex(std::string_view sequenceName) const
 	{
 		NazaraAssert(m_impl, "Animation not created");
 
@@ -233,7 +233,7 @@ namespace Nz
 		return m_impl->type;
 	}
 
-	bool Animation::HasSequence(const std::string& sequenceName) const
+	bool Animation::HasSequence(std::string_view sequenceName) const
 	{
 		NazaraAssert(m_impl, "Animation not created");
 
@@ -259,7 +259,7 @@ namespace Nz
 		return m_impl != nullptr;
 	}
 
-	void Animation::RemoveSequence(const std::string& identifier)
+	void Animation::RemoveSequence(std::string_view identifier)
 	{
 		NazaraAssert(m_impl, "Animation not created");
 

--- a/src/Nazara/Utility/Formats/MD5AnimParser.cpp
+++ b/src/Nazara/Utility/Formats/MD5AnimParser.cpp
@@ -262,7 +262,7 @@ namespace Nz
 		return true;
 	}
 
-	void MD5AnimParser::Error(const std::string& message)
+	void MD5AnimParser::Error(std::string_view message)
 	{
 		NazaraErrorFmt("{0} at line #{1}", message, m_lineCount);
 	}
@@ -504,14 +504,14 @@ namespace Nz
 		return true;
 	}
 
-	void MD5AnimParser::Warning(const std::string& message)
+	void MD5AnimParser::Warning(std::string_view message)
 	{
-		NazaraWarning(message + " at line #" + NumberToString(m_lineCount));
+		NazaraWarningFmt("{0} at line #{1}", message, m_lineCount);
 	}
 
 	void MD5AnimParser::UnrecognizedLine(bool error)
 	{
-		std::string message = "Unrecognized \"" + m_currentLine + '"';
+		std::string message = "unrecognized \"" + m_currentLine + '"';
 
 		if (error)
 			Error(message);

--- a/src/Nazara/Utility/Formats/MD5MeshParser.cpp
+++ b/src/Nazara/Utility/Formats/MD5MeshParser.cpp
@@ -209,7 +209,7 @@ namespace Nz
 		return true;
 	}
 
-	void MD5MeshParser::Error(const std::string& message)
+	void MD5MeshParser::Error(std::string_view message)
 	{
 		NazaraErrorFmt("{0} on line #{1}", message, m_lineCount);
 	}
@@ -444,14 +444,14 @@ namespace Nz
 		return true;
 	}
 
-	void MD5MeshParser::Warning(const std::string& message)
+	void MD5MeshParser::Warning(std::string_view message)
 	{
 		NazaraWarningFmt("{0} on line #{1}", message, m_lineCount);
 	}
 
 	void MD5MeshParser::UnrecognizedLine(bool error)
 	{
-		std::string message = "Unrecognized \"" + m_currentLine + '"';
+		std::string message = "unrecognized \"" + m_currentLine + '"';
 
 		if (error)
 			Error(message);

--- a/src/Nazara/Utility/Formats/MTLParser.cpp
+++ b/src/Nazara/Utility/Formats/MTLParser.cpp
@@ -14,7 +14,7 @@ namespace Nz
 	namespace
 	{
 		template<std::size_t N>
-		bool TestKeyword(const std::string& currentLine, const char(&keyword)[N], std::size_t& offset)
+		bool TestKeyword(std::string_view currentLine, const char(&keyword)[N], std::size_t& offset)
 		{
 			if (currentLine.size() > N && StartsWith(currentLine, keyword, CaseIndependent{}) && std::isspace(currentLine[N - 1]))
 			{

--- a/src/Nazara/Utility/Formats/OBJSaver.cpp
+++ b/src/Nazara/Utility/Formats/OBJSaver.cpp
@@ -57,7 +57,7 @@ namespace Nz
 			return (extension == ".obj");
 		}
 
-		bool SaveOBJToStream(const Mesh& mesh, const std::string& format, Stream& stream, const MeshParams& parameters)
+		bool SaveOBJToStream(const Mesh& mesh, std::string_view format, Stream& stream, const MeshParams& parameters)
 		{
 			NAZARA_USE_ANONYMOUS_NAMESPACE
 

--- a/src/Nazara/Utility/Formats/STBSaver.cpp
+++ b/src/Nazara/Utility/Formats/STBSaver.cpp
@@ -235,7 +235,7 @@ namespace Nz
 			return s_formatHandlers.find(extension) != s_formatHandlers.end();
 		}
 
-		bool SaveToStream(const Image& image, const std::string& format, Stream& stream, const ImageParams& parameters)
+		bool SaveToStream(const Image& image, std::string_view format, Stream& stream, const ImageParams& parameters)
 		{
 			NazaraUnused(parameters);
 
@@ -252,7 +252,7 @@ namespace Nz
 				return false;
 			}
 
-			auto it = s_formatHandlers.find(std::string_view(format));
+			auto it = s_formatHandlers.find(format);
 			NazaraAssert(it != s_formatHandlers.end(), "Invalid handler");
 
 			const FormatHandler& handler = it->second;

--- a/src/Nazara/Utility/Image.cpp
+++ b/src/Nazara/Utility/Image.cpp
@@ -1146,7 +1146,7 @@ namespace Nz
 		return utility->GetImageSaver().SaveToFile(*this, filePath, params);
 	}
 
-	bool Image::SaveToStream(Stream& stream, const std::string& format, const ImageParams& params)
+	bool Image::SaveToStream(Stream& stream, std::string_view format, const ImageParams& params)
 	{
 		Utility* utility = Utility::Instance();
 		NazaraAssert(utility, "Utility module has not been initialized");

--- a/src/Nazara/Utility/Skeleton.cpp
+++ b/src/Nazara/Utility/Skeleton.cpp
@@ -4,6 +4,7 @@
 
 #include <Nazara/Utility/Skeleton.hpp>
 #include <Nazara/Utility/Joint.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <unordered_map>
 #include <Nazara/Utility/Debug.hpp>
 
@@ -11,7 +12,7 @@ namespace Nz
 {
 	struct SkeletonImpl
 	{
-		std::unordered_map<std::string, std::size_t> jointMap;
+		std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>> jointMap;
 		std::vector<Joint> joints;
 		Boxf aabb;
 		bool aabbUpdated = false;
@@ -68,7 +69,7 @@ namespace Nz
 		return m_impl->aabb;
 	}
 
-	Joint* Skeleton::GetJoint(const std::string& jointName)
+	Joint* Skeleton::GetJoint(std::string_view jointName)
 	{
 		NazaraAssert(m_impl, "skeleton must have been created");
 
@@ -91,7 +92,7 @@ namespace Nz
 		return &m_impl->joints[index];
 	}
 
-	const Joint* Skeleton::GetJoint(const std::string& jointName) const
+	const Joint* Skeleton::GetJoint(std::string_view jointName) const
 	{
 		NazaraAssert(m_impl, "skeleton must have been created");
 
@@ -132,7 +133,7 @@ namespace Nz
 		return static_cast<std::size_t>(m_impl->joints.size());
 	}
 
-	std::size_t Skeleton::GetJointIndex(const std::string& jointName) const
+	std::size_t Skeleton::GetJointIndex(std::string_view jointName) const
 	{
 		NazaraAssert(m_impl, "skeleton must have been created");
 
@@ -259,9 +260,8 @@ namespace Nz
 			const std::string& name = m_impl->joints[i].GetName();
 			if (!name.empty())
 			{
-				NazaraAssert(m_impl->jointMap.find(name) == m_impl->jointMap.end(), "Joint name \"" + name + "\" is already present in joint map");
-
-				m_impl->jointMap[name] = static_cast<std::size_t>(i);
+				NazaraAssertFmt(!m_impl->jointMap.contains(name), "Joint name \{0}\" is already present in joint map", name);
+				m_impl->jointMap.emplace(name, i);
 			}
 		}
 

--- a/src/Nazara/VulkanRenderer/Vulkan.cpp
+++ b/src/Nazara/VulkanRenderer/Vulkan.cpp
@@ -11,6 +11,7 @@
 #include <Nazara/VulkanRenderer/VulkanDevice.hpp>
 #include <NazaraUtils/Algorithm.hpp>
 #include <NazaraUtils/CallOnExit.hpp>
+#include <NazaraUtils/StringHash.hpp>
 #include <array>
 #include <unordered_set>
 #include <Nazara/VulkanRenderer/Debug.hpp>
@@ -22,11 +23,11 @@ namespace Nz
 		struct AvailableVulkanLayer
 		{
 			VkLayerProperties layerProperties;
-			std::unordered_map<std::string, std::size_t> extensionByName;
+			std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>> extensionByName;
 			std::vector<VkExtensionProperties> extensionList;
 		};
 
-		void EnumerateVulkanLayers(std::vector<AvailableVulkanLayer>& availableLayers, std::unordered_map<std::string, std::size_t>& layerByName)
+		void EnumerateVulkanLayers(std::vector<AvailableVulkanLayer>& availableLayers, std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>>& layerByName)
 		{
 			std::vector<VkLayerProperties> layerList;
 			if (Vk::Loader::EnumerateInstanceLayerProperties(&layerList))
@@ -175,7 +176,7 @@ namespace Nz
 		std::vector<const char*> enabledLayers;
 
 		std::vector<AvailableVulkanLayer> availableLayers;
-		std::unordered_map<std::string, std::size_t> availableLayerByName;
+		std::unordered_map<std::string, std::size_t, StringHash<>, std::equal_to<>> availableLayerByName;
 		EnumerateVulkanLayers(availableLayers, availableLayerByName);
 
 		if (auto result = parameters.GetBooleanParameter("VkInstanceInfo_OverrideEnabledLayers"); !result.GetValueOr(false))
@@ -211,12 +212,12 @@ namespace Nz
 		}
 
 		// Get supported extension list
-		std::unordered_set<std::string> availableExtensions;
+		std::unordered_set<std::string, StringHash<>, std::equal_to<>> availableExtensions;
 		std::vector<VkExtensionProperties> extensionList;
 		if (Vk::Loader::EnumerateInstanceExtensionProperties(&extensionList))
 		{
 			for (VkExtensionProperties& extProperty : extensionList)
-				availableExtensions.insert(extProperty.extensionName);
+				availableExtensions.emplace(extProperty.extensionName);
 		}
 
 		if (auto result = parameters.GetBooleanParameter("VkInstanceInfo_OverrideEnabledExtensions"); !result.GetValueOr(false))

--- a/tests/UnitTests/Engine/Core/CommandLineParametersTests.cpp
+++ b/tests/UnitTests/Engine/Core/CommandLineParametersTests.cpp
@@ -1,4 +1,5 @@
 #include <Nazara/Core/CommandLineParameters.hpp>
+#include <NazaraUtils/Algorithm.hpp>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <array>


### PR DESCRIPTION
Now that Nazara uses C++20, it's possible to use maps of std::string but find keys by const char*/std::string_view (heterogeneous lookup).
NazaraUtils 2023.12.28 introduces `Nz::StringHash` which helps with this.

This should remove quite a lot of implicit std::string construction.
