### PR TITLE
Graphics/Material: Add buffer properties

### DIFF
--- a/include/Nazara/Graphics/Material.hpp
+++ b/include/Nazara/Graphics/Material.hpp
@@ -42,6 +42,7 @@ namespace Nz
 	class NAZARA_GRAPHICS_API Material : public Resource, public std::enable_shared_from_this<Material>
 	{
 		public:
+			struct StorageBufferData;
 			struct TextureData;
 			struct UniformBlockData;
 			using Params = MaterialParams;
@@ -52,12 +53,15 @@ namespace Nz
 
 			std::shared_ptr<MaterialInstance> GetDefaultInstance() const;
 
+			inline std::size_t FindStorageBufferByTag(std::string_view tag) const;
 			inline std::size_t FindTextureByTag(std::string_view tag) const;
 			inline std::size_t FindUniformBlockByTag(std::string_view tag) const;
 
 			inline UInt32 GetEngineBindingIndex(EngineShaderBinding shaderBinding) const;
 			inline const std::shared_ptr<RenderPipelineLayout>& GetRenderPipelineLayout() const;
 			inline const MaterialSettings& GetSettings() const;
+			inline const StorageBufferData& GetStorageBufferData(std::size_t storageBufferIndex) const;
+			inline std::size_t GetStorageBufferCount() const;
 			inline const TextureData& GetTextureData(std::size_t textureIndex) const;
 			inline std::size_t GetTextureCount() const;
 			inline const UniformBlockData& GetUniformBlockData(std::size_t uniformBlockIndex) const;
@@ -74,6 +78,13 @@ namespace Nz
 
 			static constexpr UInt32 InvalidBindingIndex = std::numeric_limits<UInt32>::max();
 			static constexpr std::size_t InvalidIndex = std::numeric_limits<std::size_t>::max();
+
+			struct StorageBufferData
+			{
+				UInt32 bindingSet;
+				UInt32 bindingIndex;
+				std::size_t structIndex;
+			};
 
 			struct TextureData
 			{
@@ -93,8 +104,10 @@ namespace Nz
 		private:
 			std::shared_ptr<RenderPipelineLayout> m_renderPipelineLayout;
 			std::unordered_map<UInt32, nzsl::Ast::ConstantSingleValue> m_optionValues;
+			std::unordered_map<std::string /*tag*/, std::size_t, StringHash<>, std::equal_to<>> m_storageBufferByTag;
 			std::unordered_map<std::string /*tag*/, std::size_t, StringHash<>, std::equal_to<>> m_textureByTag;
 			std::unordered_map<std::string /*tag*/, std::size_t, StringHash<>, std::equal_to<>> m_uniformBlockByTag;
+			std::vector<StorageBufferData> m_storageBuffers;
 			std::vector<TextureData> m_textures;
 			std::vector<UniformBlockData> m_uniformBlocks;
 			mutable std::weak_ptr<MaterialInstance> m_defaultInstance;

--- a/include/Nazara/Graphics/Material.inl
+++ b/include/Nazara/Graphics/Material.inl
@@ -2,9 +2,17 @@
 // This file is part of the "Nazara Engine - Graphics module"
 // For conditions of distribution and use, see copyright notice in Export.hpp
 
-
 namespace Nz
 {
+	inline std::size_t Material::FindStorageBufferByTag(std::string_view tag) const
+	{
+		auto it = m_storageBufferByTag.find(tag);
+		if (it == m_storageBufferByTag.end())
+			return InvalidIndex;
+
+		return it->second;
+	}
+
 	inline std::size_t Material::FindTextureByTag(std::string_view tag) const
 	{
 		auto it = m_textureByTag.find(tag);
@@ -36,6 +44,17 @@ namespace Nz
 	inline const MaterialSettings& Material::GetSettings() const
 	{
 		return m_settings;
+	}
+
+	inline auto Material::GetStorageBufferData(std::size_t storageBufferIndex) const ->  const StorageBufferData&
+	{
+		assert(storageBufferIndex < m_storageBuffers.size());
+		return m_storageBuffers[storageBufferIndex];
+	}
+
+	inline std::size_t Material::GetStorageBufferCount() const
+	{
+		return m_storageBuffers.size();
 	}
 
 	inline auto Material::GetTextureData(std::size_t textureIndex) const -> const TextureData&

--- a/include/Nazara/Graphics/MaterialInstance.inl
+++ b/include/Nazara/Graphics/MaterialInstance.inl
@@ -26,6 +26,11 @@ namespace Nz
 		}
 	}
 
+	inline std::size_t MaterialInstance::FindBufferProperty(std::string_view propertyName) const
+	{
+		return m_materialSettings.FindBufferProperty(propertyName);
+	}
+
 	inline std::size_t MaterialInstance::FindTextureProperty(std::string_view propertyName) const
 	{
 		return m_materialSettings.FindTextureProperty(propertyName);
@@ -34,6 +39,32 @@ namespace Nz
 	inline std::size_t MaterialInstance::FindValueProperty(std::string_view propertyName) const
 	{
 		return m_materialSettings.FindValueProperty(propertyName);
+	}
+
+	inline const MaterialSettings::BufferValue* MaterialInstance::GetBufferProperty(std::string_view propertyName) const
+	{
+		std::size_t propertyIndex = FindBufferProperty(propertyName);
+		if (propertyIndex == MaterialSettings::InvalidPropertyIndex)
+		{
+			NazaraErrorFmt("material has no storage buffer property named \"{0}\"", propertyName);
+			return nullptr;
+		}
+
+		return &GetBufferProperty(propertyIndex);
+	}
+
+	inline const MaterialSettings::BufferValue& MaterialInstance::GetBufferProperty(std::size_t storageBufferIndex) const
+	{
+		if (const MaterialSettings::BufferValue& storageBufferOverride = GetBufferPropertyOverride(storageBufferIndex); storageBufferOverride.buffer)
+			return storageBufferOverride;
+		else
+			return m_materialSettings.GetBufferProperty(storageBufferIndex).defaultValue;
+	}
+
+	inline const MaterialSettings::BufferValue& MaterialInstance::GetBufferPropertyOverride(std::size_t storageBufferIndex) const
+	{
+		assert(storageBufferIndex < m_bufferOverride.size());
+		return m_bufferOverride[storageBufferIndex];
 	}
 
 	inline const std::shared_ptr<const Material>& MaterialInstance::GetParentMaterial() const
@@ -120,6 +151,18 @@ namespace Nz
 	inline bool MaterialInstance::HasPass(std::size_t passIndex) const
 	{
 		return passIndex < m_passes.size() && m_passes[passIndex].enabled;
+	}
+
+	inline void MaterialInstance::SetBufferProperty(std::string_view propertyName, const MaterialSettings::BufferValue& value)
+	{
+		std::size_t propertyIndex = FindBufferProperty(propertyName);
+		if (propertyIndex == MaterialSettings::InvalidPropertyIndex)
+		{
+			NazaraErrorFmt("material has no buffer property named \"{0}\"", propertyName);
+			return;
+		}
+
+		return SetBufferProperty(propertyIndex, value);
 	}
 
 	inline void MaterialInstance::SetTextureProperty(std::string_view propertyName, std::shared_ptr<TextureAsset> texture)
@@ -229,4 +272,3 @@ namespace Nz
 		OnMaterialInstanceShaderBindingInvalidated(this);
 	}
 }
-

--- a/include/Nazara/Graphics/MaterialSettings.hpp
+++ b/include/Nazara/Graphics/MaterialSettings.hpp
@@ -47,6 +47,8 @@ namespace Nz
 	class NAZARA_GRAPHICS_API MaterialSettings
 	{
 		public:
+			struct BufferProperty;
+			struct BufferValue;
 			struct TextureProperty;
 			struct ValueProperty;
 
@@ -57,19 +59,29 @@ namespace Nz
 			MaterialSettings(MaterialSettings&&) noexcept = default;
 			~MaterialSettings() = default;
 
+			inline void AddBufferProperty(std::string propertyName);
+			void AddBufferProperty(std::string propertyName, std::shared_ptr<RenderBuffer> defaultBuffer);
+			void AddBufferProperty(std::string propertyName, std::shared_ptr<RenderBuffer> defaultBuffer, UInt64 defaultOffset, UInt64 defaultSize);
+
 			void AddPass(std::string_view passName, MaterialPass materialPass);
 			inline void AddPass(std::size_t passIndex, MaterialPass materialPass);
+
 			inline void AddPropertyHandler(std::unique_ptr<PropertyHandler> propertyHandler);
+
 			inline void AddTextureProperty(std::string propertyName, ImageType propertyType);
 			void AddTextureProperty(std::string propertyName, ImageType propertyType, std::shared_ptr<TextureAsset> defaultTexture);
 			void AddTextureProperty(std::string propertyName, ImageType propertyType, std::shared_ptr<TextureAsset> defaultTexture, const TextureSamplerInfo& defaultSamplerInfo);
+
 			inline void AddValueProperty(std::string propertyName, MaterialPropertyType propertyType, Value defaultValue);
 			template<typename T> void AddValueProperty(std::string propertyName);
 			template<typename T, typename U> void AddValueProperty(std::string propertyName, U&& defaultValue);
 
+			inline std::size_t FindBufferProperty(std::string_view propertyName) const;
 			inline std::size_t FindTextureProperty(std::string_view propertyName) const;
 			inline std::size_t FindValueProperty(std::string_view propertyName) const;
 
+			inline const BufferProperty& GetBufferProperty(std::size_t storageBufferPropertyIndex) const;
+			inline std::size_t GetBufferPropertyCount() const;
 			const MaterialPass* GetPass(std::string_view passName) const;
 			inline const MaterialPass* GetPass(std::size_t passIndex) const;
 			inline const std::vector<std::optional<MaterialPass>>& GetPasses() const;
@@ -81,6 +93,19 @@ namespace Nz
 
 			MaterialSettings& operator=(const MaterialSettings&) = delete;
 			MaterialSettings& operator=(MaterialSettings&&) = default;
+
+			struct BufferValue
+			{
+				std::shared_ptr<RenderBuffer> buffer;
+				UInt64 offset = 0;
+				UInt64 size = 0;
+			};
+
+			struct BufferProperty
+			{
+				std::string name;
+				BufferValue defaultValue;
+			};
 
 			struct TextureProperty
 			{
@@ -102,6 +127,7 @@ namespace Nz
 		private:
 			std::vector<std::unique_ptr<PropertyHandler>> m_propertyHandlers;
 			std::vector<std::optional<MaterialPass>> m_materialPasses;
+			std::vector<BufferProperty> m_bufferProperties;
 			std::vector<TextureProperty> m_textureProperties;
 			std::vector<ValueProperty> m_valueProperties;
 	};

--- a/include/Nazara/Graphics/MaterialSettings.hpp
+++ b/include/Nazara/Graphics/MaterialSettings.hpp
@@ -15,7 +15,6 @@
 #include <Nazara/Math/Vector2.hpp>
 #include <Nazara/Math/Vector3.hpp>
 #include <Nazara/Math/Vector4.hpp>
-#include <Nazara/Renderer/Texture.hpp>
 #include <NazaraUtils/TypeList.hpp>
 #include <limits>
 #include <optional>
@@ -42,6 +41,7 @@ namespace Nz
 		UInt32, Vector2<UInt32>, Vector3<UInt32>, Vector4<UInt32>
 	>;
 
+	class RenderBuffer;
 	class TextureAsset;
 
 	class NAZARA_GRAPHICS_API MaterialSettings
@@ -94,8 +94,11 @@ namespace Nz
 			MaterialSettings& operator=(const MaterialSettings&) = delete;
 			MaterialSettings& operator=(MaterialSettings&&) = default;
 
-			struct BufferValue
+			struct NAZARA_GRAPHICS_API BufferValue
 			{
+				BufferValue() = default;
+				BufferValue(std::shared_ptr<RenderBuffer> buffer);
+
 				std::shared_ptr<RenderBuffer> buffer;
 				UInt64 offset = 0;
 				UInt64 size = 0;

--- a/include/Nazara/Graphics/MaterialSettings.inl
+++ b/include/Nazara/Graphics/MaterialSettings.inl
@@ -180,6 +180,11 @@ namespace Nz
 	template<> struct MaterialPropertyTypeInfo<MaterialPropertyType::UInt4> : MaterialPropertyTypeInfoVector<UInt32, 4> {};
 
 
+	inline void MaterialSettings::AddBufferProperty(std::string propertyName)
+	{
+		return AddBufferProperty(std::move(propertyName), nullptr, 0, 0);
+	}
+
 	inline void MaterialSettings::AddPass(std::size_t passIndex, MaterialPass materialPass)
 	{
 		if (passIndex >= m_materialPasses.size())
@@ -222,6 +227,17 @@ namespace Nz
 		valueProperty.defaultValue = std::move(defaultValue);
 	}
 
+	inline std::size_t MaterialSettings::FindBufferProperty(std::string_view propertyName) const
+	{
+		for (std::size_t i = 0; i < m_bufferProperties.size(); ++i)
+		{
+			if (m_bufferProperties[i].name == propertyName)
+				return i;
+		}
+
+		return InvalidPropertyIndex;
+	}
+
 	inline std::size_t MaterialSettings::FindTextureProperty(std::string_view propertyName) const
 	{
 		for (std::size_t i = 0; i < m_textureProperties.size(); ++i)
@@ -242,6 +258,17 @@ namespace Nz
 		}
 
 		return InvalidPropertyIndex;
+	}
+
+	inline auto MaterialSettings::GetBufferProperty(std::size_t bufferProperty) const -> const BufferProperty&
+	{
+		assert(bufferProperty < m_bufferProperties.size());
+		return m_bufferProperties[bufferProperty];
+	}
+
+	inline std::size_t MaterialSettings::GetBufferPropertyCount() const
+	{
+		return m_bufferProperties.size();
 	}
 
 	inline const MaterialPass* MaterialSettings::GetPass(std::size_t passIndex) const
@@ -301,4 +328,3 @@ namespace Nz
 		valueProperty.defaultValue.emplace<TypeIndex>(std::forward<U>(defaultValue));
 	}
 }
-

--- a/include/Nazara/Graphics/Model.hpp
+++ b/include/Nazara/Graphics/Model.hpp
@@ -63,6 +63,7 @@ namespace Nz
 			const std::vector<RenderPipelineInfo::VertexBufferData>& GetVertexBufferData(std::size_t subMeshIndex) const;
 			const std::shared_ptr<RenderBuffer>& GetVertexBuffer(std::size_t subMeshIndex) const;
 
+			inline void SetIndexCount(std::size_t subMeshIndex, std::size_t indexCount);
 			inline void SetMaterial(std::size_t subMeshIndex, std::shared_ptr<MaterialInstance> material);
 
 			Model& operator=(const Model&) = delete;
@@ -75,6 +76,7 @@ namespace Nz
 		private:
 			struct SubMeshData
 			{
+				std::size_t indexCount = 0; //< if != 0 overrides GraphicalMesh index count
 				std::shared_ptr<MaterialInstance> material;
 				std::vector<RenderPipelineInfo::VertexBufferData> vertexBufferData;
 			};

--- a/include/Nazara/Graphics/Model.inl
+++ b/include/Nazara/Graphics/Model.inl
@@ -11,15 +11,26 @@ namespace Nz
 		return m_submeshes.size();
 	}
 
-	inline void Model::SetMaterial(std::size_t subMeshIndex, std::shared_ptr<MaterialInstance> material)
+	inline void Model::SetIndexCount(std::size_t submeshIndex, std::size_t indexCount)
 	{
-		NazaraAssertFmt(subMeshIndex < m_submeshes.size(), "submesh index out of range ({0} >= {1})", subMeshIndex, m_submeshes.size());
+		NazaraAssertFmt(submeshIndex < m_submeshes.size(), "submesh index out of range ({0} >= {1})", submeshIndex, m_submeshes.size());
+
+		if (m_submeshes[submeshIndex].indexCount != indexCount)
+		{
+			m_submeshes[submeshIndex].indexCount = indexCount;
+			OnElementInvalidated(this);
+		}
+	}
+
+	inline void Model::SetMaterial(std::size_t submeshIndex, std::shared_ptr<MaterialInstance> material)
+	{
+		NazaraAssertFmt(submeshIndex < m_submeshes.size(), "submesh index out of range ({0} >= {1})", submeshIndex, m_submeshes.size());
 		NazaraAssert(material, "invalid material");
 
-		if (m_submeshes[subMeshIndex].material != material)
+		if (m_submeshes[submeshIndex].material != material)
 		{
-			OnMaterialInvalidated(this, subMeshIndex, material);
-			m_submeshes[subMeshIndex].material = std::move(material);
+			OnMaterialInvalidated(this, submeshIndex, material);
+			m_submeshes[submeshIndex].material = std::move(material);
 
 			OnElementInvalidated(this);
 		}

--- a/include/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.hpp
+++ b/include/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com)
+// This file is part of the "Nazara Engine - Graphics module"
+// For conditions of distribution and use, see copyright notice in Export.hpp
+
+#pragma once
+
+#ifndef NAZARA_GRAPHICS_PROPERTYHANDLER_BUFFERPROPERTYHANDLER_HPP
+#define NAZARA_GRAPHICS_PROPERTYHANDLER_BUFFERPROPERTYHANDLER_HPP
+
+#include <NazaraUtils/Prerequisites.hpp>
+#include <Nazara/Graphics/Export.hpp>
+#include <Nazara/Graphics/PropertyHandler/PropertyHandler.hpp>
+#include <string>
+
+namespace Nz
+{
+	class NAZARA_GRAPHICS_API BufferPropertyHandler : public PropertyHandler
+	{
+		public:
+			inline BufferPropertyHandler(std::string propertyName);
+			inline BufferPropertyHandler(std::string propertyName, std::string optionName);
+			inline BufferPropertyHandler(std::string propertyName, std::string bufferTag, std::string optionName);
+			BufferPropertyHandler(const BufferPropertyHandler&) = delete;
+			BufferPropertyHandler(BufferPropertyHandler&&) = delete;
+			~BufferPropertyHandler() = default;
+
+			bool NeedsUpdateOnStorageBufferUpdate(std::size_t updatedPropertyIndex) const override;
+
+			void Setup(const Material& material, const ShaderReflection& reflection) override;
+
+			void Update(MaterialInstance& materialInstance) const override;
+
+			BufferPropertyHandler& operator=(const BufferPropertyHandler&) = delete;
+			BufferPropertyHandler& operator=(BufferPropertyHandler&&) = delete;
+
+		private:
+			std::size_t m_propertyIndex;
+			std::size_t m_storageBufferIndex;
+			std::string m_bufferTag;
+			std::string m_optionName;
+			std::string m_propertyName;
+			UInt32 m_optionHash;
+	};
+}
+
+#include <Nazara/Graphics/PropertyHandler/BufferPropertyHandler.inl>
+
+#endif // NAZARA_GRAPHICS_PROPERTYHANDLER_BUFFERPROPERTYHANDLER_HPP

--- a/include/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.inl
+++ b/include/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.inl
@@ -1,0 +1,27 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com)
+// This file is part of the "Nazara Engine - Graphics module"
+// For conditions of distribution and use, see copyright notice in Export.hpp
+
+namespace Nz
+{
+	inline BufferPropertyHandler::BufferPropertyHandler(std::string propertyName) :
+	m_bufferTag(std::move(propertyName)),
+	m_propertyName(m_bufferTag)
+	{
+	}
+
+	inline BufferPropertyHandler::BufferPropertyHandler(std::string propertyName, std::string optionName) :
+	m_bufferTag(std::move(propertyName)),
+	m_optionName(std::move(optionName)),
+	m_propertyName(m_bufferTag)
+	{
+	}
+
+	inline Nz::BufferPropertyHandler::BufferPropertyHandler(std::string propertyName, std::string bufferTag, std::string optionName):
+	m_bufferTag(std::move(bufferTag)),
+	m_optionName(std::move(optionName)),
+	m_propertyName(std::move(propertyName))
+	{
+	}
+}
+

--- a/include/Nazara/Graphics/PropertyHandler/PropertyHandler.hpp
+++ b/include/Nazara/Graphics/PropertyHandler/PropertyHandler.hpp
@@ -26,6 +26,7 @@ namespace Nz
 			PropertyHandler(PropertyHandler&&) = delete;
 			virtual ~PropertyHandler();
 
+			virtual bool NeedsUpdateOnStorageBufferUpdate(std::size_t updatedStorageBufferPropertyIndex) const;
 			virtual bool NeedsUpdateOnTextureUpdate(std::size_t updatedTexturePropertyIndex) const;
 			virtual bool NeedsUpdateOnValueUpdate(std::size_t updatedValuePropertyIndex) const;
 

--- a/src/Nazara/Graphics/Material.cpp
+++ b/src/Nazara/Graphics/Material.cpp
@@ -61,7 +61,17 @@ namespace Nz
 				m_textureByTag.emplace(tag, textureIndex);
 			}
 
-			assert(block->storageBlocks.empty()); //< TODO
+			for (const auto& [tag, storageBlock] : block->storageBlocks)
+			{
+				std::size_t storageBufferIndex = m_storageBuffers.size();
+
+				auto& storageBuffer = m_storageBuffers.emplace_back();
+				storageBuffer.bindingIndex = storageBlock.bindingIndex;
+				storageBuffer.bindingSet = storageBlock.bindingSet;
+				storageBuffer.structIndex = storageBlock.structIndex;
+
+				m_storageBufferByTag.emplace(tag, storageBufferIndex);
+			}
 
 			for (const auto& [tag, shaderBlock] : block->uniformBlocks)
 			{

--- a/src/Nazara/Graphics/MaterialSettings.cpp
+++ b/src/Nazara/Graphics/MaterialSettings.cpp
@@ -5,6 +5,7 @@
 #include <Nazara/Graphics/MaterialSettings.hpp>
 #include <Nazara/Graphics/Graphics.hpp>
 #include <Nazara/Graphics/TextureAsset.hpp>
+#include <Nazara/Renderer/RenderBuffer.hpp>
 
 namespace Nz
 {
@@ -12,6 +13,23 @@ namespace Nz
 	{
 		std::size_t passIndex = Graphics::Instance()->GetMaterialPassRegistry().GetPassIndex(passName);
 		return AddPass(passIndex, std::move(materialPass));
+	}
+
+	void MaterialSettings::AddBufferProperty(std::string propertyName, std::shared_ptr<RenderBuffer> defaultBuffer)
+	{
+		UInt64 size = (defaultBuffer) ? defaultBuffer->GetSize() : 0;
+		return AddBufferProperty(std::move(propertyName), std::move(defaultBuffer), 0, size);
+	}
+
+	void MaterialSettings::AddBufferProperty(std::string propertyName, std::shared_ptr<RenderBuffer> defaultBuffer, UInt64 defaultOffset, UInt64 defaultSize)
+	{
+		NazaraAssert(!defaultBuffer || defaultBuffer->GetType() == Nz::BufferType::Storage, "a default buffer was passed but wasn't a storage buffer");
+
+		auto& storageBufferProperty = m_bufferProperties.emplace_back();
+		storageBufferProperty.name = std::move(propertyName);
+		storageBufferProperty.defaultValue.buffer = std::move(defaultBuffer);
+		storageBufferProperty.defaultValue.offset = defaultOffset;
+		storageBufferProperty.defaultValue.size = defaultSize;
 	}
 
 	void MaterialSettings::AddTextureProperty(std::string propertyName, ImageType propertyType, std::shared_ptr<TextureAsset> defaultTexture)

--- a/src/Nazara/Graphics/MaterialSettings.cpp
+++ b/src/Nazara/Graphics/MaterialSettings.cpp
@@ -60,4 +60,11 @@ namespace Nz
 		std::size_t passIndex = Graphics::Instance()->GetMaterialPassRegistry().GetPassIndex(passName);
 		return GetPass(passIndex);
 	}
+
+	MaterialSettings::BufferValue::BufferValue(std::shared_ptr<RenderBuffer> buffer) :
+	buffer(buffer)
+	{
+		if (buffer)
+			size = buffer->GetSize();
+	}
 }

--- a/src/Nazara/Graphics/Model.cpp
+++ b/src/Nazara/Graphics/Model.cpp
@@ -59,7 +59,7 @@ namespace Nz
 			const auto& vertexBuffer = m_graphicalMesh->GetVertexBuffer(i);
 			const auto& renderPipeline = materialPipeline->GetRenderPipeline(submeshData.vertexBufferData.data(), submeshData.vertexBufferData.size());
 
-			std::size_t indexCount = m_graphicalMesh->GetIndexCount(i);
+			std::size_t indexCount = (submeshData.indexCount != 0) ? submeshData.indexCount : m_graphicalMesh->GetIndexCount(i);
 			IndexType indexType = m_graphicalMesh->GetIndexType(i);
 
 			elements.emplace_back(registry.AllocateElement<RenderSubmesh>(GetRenderLayer(), submeshData.material, passFlags, renderPipeline, *elementData.worldInstance, elementData.skeletonInstance, indexCount, indexType, indexBuffer, vertexBuffer, *elementData.scissorBox));

--- a/src/Nazara/Graphics/Model.cpp
+++ b/src/Nazara/Graphics/Model.cpp
@@ -26,12 +26,15 @@ namespace Nz
 		{
 			auto& subMeshData = m_submeshes.emplace_back();
 			subMeshData.material = MaterialInstance::GetDefault(MaterialType::Basic);
-			subMeshData.vertexBufferData = {
-				{
-					0,
-					m_graphicalMesh->GetVertexDeclaration(i)
-				}
-			};
+			if (const auto& vertexDeclaration = m_graphicalMesh->GetVertexDeclaration(i))
+			{
+				subMeshData.vertexBufferData = {
+					{
+						0,
+						vertexDeclaration
+					}
+				};
+			}
 		}
 
 		m_onInvalidated.Connect(m_graphicalMesh->OnInvalidated, [this](GraphicalMesh*)

--- a/src/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.cpp
+++ b/src/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.cpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com)
+// This file is part of the "Nazara Engine - Graphics module"
+// For conditions of distribution and use, see copyright notice in Export.hpp
+
+#include <Nazara/Graphics/PropertyHandler/BufferPropertyHandler.hpp>
+#include <Nazara/Graphics/Material.hpp>
+#include <Nazara/Graphics/MaterialInstance.hpp>
+
+namespace Nz
+{
+	bool BufferPropertyHandler::NeedsUpdateOnStorageBufferUpdate(std::size_t updatedPropertyIndex) const
+	{
+		return m_propertyIndex == updatedPropertyIndex;
+	}
+
+	void BufferPropertyHandler::Setup(const Material& material, const ShaderReflection& reflection)
+	{
+		m_propertyIndex = MaterialSettings::InvalidPropertyIndex;
+
+		const MaterialSettings& settings = material.GetSettings();
+
+		std::size_t propertyIndex = settings.FindBufferProperty(m_propertyName);
+		if (propertyIndex == MaterialSettings::InvalidPropertyIndex)
+			return;
+
+		m_propertyIndex = propertyIndex;
+
+		m_storageBufferIndex = material.FindStorageBufferByTag(m_bufferTag);
+		if (m_storageBufferIndex == Material::InvalidIndex)
+			return;
+
+		m_optionHash = 0;
+		if (!m_optionName.empty())
+		{
+			if (const ShaderReflection::OptionData* optionData = reflection.GetOptionByName(m_optionName))
+			{
+				if (IsPrimitiveType(optionData->type) && std::get<nzsl::Ast::PrimitiveType>(optionData->type) == nzsl::Ast::PrimitiveType::Boolean)
+				{
+					NazaraAssert(optionData->hash != 0, "unexpected option hash");
+					m_optionHash = optionData->hash;
+				}
+				else
+					NazaraErrorFmt("option {0} is not a boolean option (got {1})", m_optionName, nzsl::Ast::ToString(optionData->type));
+			}
+			else
+				NazaraWarningFmt("option {0} not found in shader for property {1}", m_optionName, m_propertyName);
+		}
+	}
+
+	void BufferPropertyHandler::Update(MaterialInstance& materialInstance) const
+	{
+		if (m_propertyIndex == MaterialSettings::InvalidPropertyIndex)
+			return;
+
+		const MaterialSettings::BufferValue& storageBuffer = materialInstance.GetBufferProperty(m_propertyIndex);
+
+		materialInstance.UpdateStorageBufferBinding(m_storageBufferIndex, storageBuffer.buffer, storageBuffer.offset, storageBuffer.size);
+		if (m_optionHash != 0)
+			materialInstance.UpdateOptionValue(m_optionHash, storageBuffer.buffer != nullptr);
+	}
+}

--- a/src/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.cpp
+++ b/src/Nazara/Graphics/PropertyHandler/BufferPropertyHandler.cpp
@@ -53,6 +53,8 @@ namespace Nz
 			return;
 
 		const MaterialSettings::BufferValue& storageBuffer = materialInstance.GetBufferProperty(m_propertyIndex);
+		if (!storageBuffer.buffer)
+			return;
 
 		materialInstance.UpdateStorageBufferBinding(m_storageBufferIndex, storageBuffer.buffer, storageBuffer.offset, storageBuffer.size);
 		if (m_optionHash != 0)

--- a/src/Nazara/Graphics/PropertyHandler/PropertyHandler.cpp
+++ b/src/Nazara/Graphics/PropertyHandler/PropertyHandler.cpp
@@ -8,6 +8,11 @@ namespace Nz
 {
 	PropertyHandler::~PropertyHandler() = default;
 
+	bool PropertyHandler::NeedsUpdateOnStorageBufferUpdate(std::size_t /*updatedStorageBufferPropertyIndex*/) const
+	{
+		return false;
+	}
+
 	bool PropertyHandler::NeedsUpdateOnTextureUpdate(std::size_t /*updatedTexturePropertyIndex*/) const
 	{
 		return false;

--- a/src/Nazara/Graphics/ShaderReflection.cpp
+++ b/src/Nazara/Graphics/ShaderReflection.cpp
@@ -165,13 +165,14 @@ namespace Nz
 		if (!node.description.layout.HasValue())
 			return;
 
-		if (node.description.layout.GetResultingValue() != nzsl::Ast::MemoryLayout::Std140)
-			throw std::runtime_error("unexpected layout for struct " + node.description.name);
-
 		if (node.description.conditionIndex != 0 || m_isConditional)
 			throw std::runtime_error("struct " + node.description.name + " condition must be resolved");
 
-		StructData structData(nzsl::StructLayout::Std140);
+		nzsl::Ast::MemoryLayout structLayout = node.description.layout.GetResultingValue();
+		if (structLayout != nzsl::Ast::MemoryLayout::Std140 && structLayout != nzsl::Ast::MemoryLayout::Std430)
+			throw std::runtime_error("unexpected layout for struct " + node.description.name);
+
+		StructData structData((structLayout == nzsl::Ast::MemoryLayout::Std140) ? nzsl::StructLayout::Std140 : nzsl::StructLayout::Std430);
 
 		for (auto& member : node.description.members)
 		{

--- a/src/Nazara/Graphics/SubmeshRenderer.cpp
+++ b/src/Nazara/Graphics/SubmeshRenderer.cpp
@@ -329,7 +329,9 @@ namespace Nz
 
 			if (currentVertexBuffer != drawData.vertexBuffer)
 			{
-				commandBuffer.BindVertexBuffer(0, *drawData.vertexBuffer);
+				if (drawData.vertexBuffer)
+					commandBuffer.BindVertexBuffer(0, *drawData.vertexBuffer);
+
 				currentVertexBuffer = drawData.vertexBuffer;
 			}
 


### PR DESCRIPTION
Allow material instances to bind storage buffers (SSBO) as properties.

For now only storage buffers are expected (because UBO are owned by material instances, I'm not sure how to expose shared UBO).